### PR TITLE
Substitution of deprecated classes in tests

### DIFF
--- a/constrained/src/test/scala/scalax/collection/constrained/TConstrained.scala
+++ b/constrained/src/test/scala/scalax/collection/constrained/TConstrained.scala
@@ -3,7 +3,7 @@ package scalax.collection.constrained
 import scala.language.{higherKinds, postfixOps}
 import scala.collection.Set
   
-import org.scalatest.{Suite, Suites}
+import org.scalatest.{Spec, Suites}
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.Ignore
@@ -45,7 +45,7 @@ class TConstrainedRootTest
 
 class TConstrained [CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: GraphConstrainedCompanion[CC])
-  extends Suite
+  extends Spec
   with    ShouldMatchers
 {
   def test_0(info : Informer) {

--- a/constrained/src/test/scala/scalax/collection/constrained/constraints/TAcyclic.scala
+++ b/constrained/src/test/scala/scalax/collection/constrained/constraints/TAcyclic.scala
@@ -3,7 +3,7 @@ package constraints
 
 import scala.language.{higherKinds, postfixOps}
 
-import org.scalatest.{Suite, Suites}
+import org.scalatest.{Spec, Suites}
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
 
@@ -36,7 +36,7 @@ class TAcyclicRootTest
 
 class TAcyclic [CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: GraphConstrainedCompanion[CC])
-  extends Suite
+  extends Spec
   with    ShouldMatchers
 {
   import AcyclicWithException._

--- a/constrained/src/test/scala/scalax/collection/constrained/constraints/TConnected.scala
+++ b/constrained/src/test/scala/scalax/collection/constrained/constraints/TConnected.scala
@@ -3,7 +3,7 @@ package constraints
 
 import scala.language.{higherKinds, postfixOps}
 
-import org.scalatest.{Suite, Suites}
+import org.scalatest.{Spec, Suites}
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
 
@@ -66,7 +66,7 @@ class TConnectedRootTest
 
 class TConnected [CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: GraphConstrainedCompanion[CC])
-  extends Suite
+  extends Spec
   with    ShouldMatchers
 {
   implicit val config: Config = Connected 

--- a/core/src/main/scala/scalax/collection/GraphTraversal.scala
+++ b/core/src/main/scala/scalax/collection/GraphTraversal.scala
@@ -385,7 +385,8 @@ trait GraphTraversal[N, E[X] <: EdgeLikeIn[X]] extends GraphBase[N,E] {
    */
   trait ExtendedNodeVisitor
       extends (NodeT => VisitorReturn)
-      with ((NodeT, Int, Int, => NodeInformer) => VisitorReturn) {
+      with ((NodeT, Int, Int, => NodeInformer) => VisitorReturn) 
+      with Serializable {
     def apply(node: NodeT) = apply(node, 0, 0, NodeInformer.empty)
   }
   object ExtendedNodeVisitor {

--- a/core/src/main/scala/scalax/collection/immutable/AdjacencyListBase.scala
+++ b/core/src/main/scala/scalax/collection/immutable/AdjacencyListBase.scala
@@ -52,7 +52,7 @@ trait AdjacencyListBase[N,
            else size
                
     @inline final protected def nodeEqThis = (n: NodeT) => n eq this
-    @transient protected[collection] object Adj { // lazy adjacents
+    @transient protected[collection] object Adj extends Serializable { // lazy adjacents
       @transient var aHook: Option[(NodeT, EdgeT)] = None
       @transient val diSucc: EqHashMap[NodeT, EdgeT] = {
         val m = new EqHashMap[NodeT, EdgeT](edges.size)

--- a/core/src/test/scala/custom/TExtByImplicit.scala
+++ b/core/src/test/scala/custom/TExtByImplicit.scala
@@ -6,14 +6,14 @@ import scalax.collection.Graph
 import scalax.collection.GraphPredef._
 import scalax.collection.GraphEdge._
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 
 @RunWith(classOf[JUnitRunner])
 class TExtByImplicitTest
-	extends	Suite
+	extends	Spec
 	with	  ShouldMatchers
 {
   def test_graphEnrichment {

--- a/core/src/test/scala/custom/TExtNode.scala
+++ b/core/src/test/scala/custom/TExtNode.scala
@@ -7,7 +7,7 @@ import scalax.collection.GraphPredef._,
 import immutable.{MyExtGraph => Graph}
 import mutable.{MyExtGraph => MutableGraph}
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.matchers.ShouldMatchers
 
 import org.scalatest.junit.JUnitRunner
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith
 
 @RunWith(classOf[JUnitRunner])
 class TExtNodeTest
-	extends	Suite
+	extends	Spec
 	with	  ShouldMatchers
 {
   def test_helloAdjacents {

--- a/core/src/test/scala/custom/flight/TFlight.scala
+++ b/core/src/test/scala/custom/flight/TFlight.scala
@@ -7,7 +7,7 @@ import scalax.collection.GraphPredef._,
        scalax.collection.GraphEdge._
 import scalax.collection.generic.GraphCompanion
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Suites
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
@@ -34,7 +34,7 @@ class TFlightRootTest
  */
 class TFlight[CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
 			(val factory: GraphCompanion[CC])
-	extends	Suite
+	extends	Spec
 	with	ShouldMatchers
 {
   val (ham, gig) = (Airport("HAM"), Airport("GIG"))

--- a/core/src/test/scala/scalax/collection/TCycle.scala
+++ b/core/src/test/scala/scalax/collection/TCycle.scala
@@ -11,7 +11,7 @@ import generic.GraphCoreCompanion
 import edge._, edge.WBase._, edge.LBase._, edge.WLBase._
 import io._
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Suites
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
@@ -33,7 +33,7 @@ class TCycleRootTest
  */
 class TCycle[CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: GraphCoreCompanion[CC])
-	extends	Suite
+	extends	Spec
 	with	ShouldMatchers
 {
   // ----------------------------------------------------------------- directed

--- a/core/src/test/scala/scalax/collection/TDegree.scala
+++ b/core/src/test/scala/scalax/collection/TDegree.scala
@@ -3,7 +3,7 @@ package scalax.collection
 import language.{higherKinds, postfixOps}
 import collection.{SortedSet, SortedMap}
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Suites
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
@@ -24,7 +24,7 @@ class TDegreeRootTest
  */
 class TDegree[CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: GraphCoreCompanion[CC])
-	extends	Suite
+	extends	Spec
 	with	  ShouldMatchers
 {
   val emptyG = factory.empty[Int,DiEdge]

--- a/core/src/test/scala/scalax/collection/TEdge.scala
+++ b/core/src/test/scala/scalax/collection/TEdge.scala
@@ -1,6 +1,6 @@
 package scalax.collection
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
 
@@ -14,7 +14,7 @@ import custom.flight._,
        custom.flight.FlightImplicits._
 
 @RunWith(classOf[JUnitRunner])
-class TEdgeTest extends Suite with ShouldMatchers
+class TEdgeTest extends Spec with ShouldMatchers
 {
   object FlightLabel extends LEdgeImplicits[Flight]
   import FlightLabel._

--- a/core/src/test/scala/scalax/collection/TEdit.scala
+++ b/core/src/test/scala/scalax/collection/TEdit.scala
@@ -4,7 +4,7 @@ import language.{higherKinds, postfixOps}
 import scala.collection.generic.CanBuildFrom
 import scala.reflect.runtime.universe._
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Suites
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
@@ -261,8 +261,8 @@ class TEditRootTest
  */
 class TEdit[CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: ConfigWrapper[CC])
-	extends	Suite
-	with	  ShouldMatchers
+	extends	Spec
+	with	ShouldMatchers
 {
   implicit val config = factory.config
 

--- a/core/src/test/scala/scalax/collection/TEquals.scala
+++ b/core/src/test/scala/scalax/collection/TEquals.scala
@@ -5,7 +5,7 @@ import language.{higherKinds, postfixOps}
 import GraphPredef._, GraphEdge._
 import generic.GraphCoreCompanion
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Suites
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
@@ -40,7 +40,7 @@ class TEqualsRootTest
  */
 class TEquals[CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: GraphCoreCompanion[CC])
-	extends	Suite
+	extends	Spec
 	with	ShouldMatchers
 {
   val g = factory(1~2, 2~3, 2~4, 3~5, 4~5)

--- a/core/src/test/scala/scalax/collection/TOp.scala
+++ b/core/src/test/scala/scalax/collection/TOp.scala
@@ -5,7 +5,7 @@ import language.{higherKinds, postfixOps}
 import GraphPredef._, GraphEdge._
 import generic.GraphCoreCompanion
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Suites
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
@@ -53,7 +53,7 @@ class TOpRootTest
  */
 class TOp[CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: GraphCoreCompanion[CC])
-	extends	Suite
+	extends	Spec
 	with	ShouldMatchers
 {
   val g = factory(1~2, 2~3, 2~4, 3~5, 4~5)

--- a/core/src/test/scala/scalax/collection/TSerializable.scala
+++ b/core/src/test/scala/scalax/collection/TSerializable.scala
@@ -4,7 +4,7 @@ import java.io._
 
 import language.higherKinds
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Suites
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
@@ -25,8 +25,8 @@ class TSerializableRootTest
  */
 class TSerializable[CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: GraphCoreCompanion[CC])
-	extends	Suite
-	with	  ShouldMatchers
+	extends	Spec
+	with	ShouldMatchers
 	with    BeforeAndAfterEach
 {
   def test_0(info : Informer) {

--- a/core/src/test/scala/scalax/collection/TState.scala
+++ b/core/src/test/scala/scalax/collection/TState.scala
@@ -11,7 +11,7 @@ import GraphPredef._, GraphEdge._
 import GraphTraversal.VisitorReturn._
 import generator.{RandomGraph, NodeDegreeRange}
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Informer
 import org.scalatest.Matchers
 
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 /** Ensure that stateful data handling used for traversals is thread-safe. 
  */
 @RunWith(classOf[JUnitRunner])
-class TStateTest extends Suite with Matchers {
+class TStateTest extends Spec with Matchers {
   val g = Graph(Data.elementsOfUnDi_2: _*)
 
   // a sample traversal with recursive calls in its node visitor

--- a/core/src/test/scala/scalax/collection/TTraversal.scala
+++ b/core/src/test/scala/scalax/collection/TTraversal.scala
@@ -11,7 +11,7 @@ import generic.GraphCoreCompanion
 import edge.WDiEdge, edge.WUnDiEdge, edge.Implicits._
 import generator.GraphGen
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Suites
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
@@ -39,7 +39,7 @@ class TTraversalRootTest
  */
 private class TTraversal[G[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,G]]
 			(val factory: GraphCoreCompanion[G])
-	extends	Suite
+	extends	Spec
 	with	ShouldMatchers
 	with	PropertyChecks
 {

--- a/core/src/test/scala/scalax/collection/mutable/TArraySet.scala
+++ b/core/src/test/scala/scalax/collection/mutable/TArraySet.scala
@@ -1,7 +1,7 @@
 package scalax.collection
 package mutable
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
 
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith
 
 /** Tests [[ArraySet]]. */
 @RunWith(classOf[JUnitRunner])
-class TArraySetTest extends Suite with ShouldMatchers {
+class TArraySetTest extends Spec with ShouldMatchers {
   implicit val hints = ArraySet.Hints(4, 4, 12, 100)
   private class LkDiEdgeGenerator {
     private var i = 0

--- a/core/src/test/scala/scalax/collection/mutable/TExtHashSet.scala
+++ b/core/src/test/scala/scalax/collection/mutable/TExtHashSet.scala
@@ -1,7 +1,7 @@
 package scalax.collection
 package mutable
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.matchers.ShouldMatchers
 
 import GraphPredef._, GraphEdge._
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith
 /** Tests [[ExtHashSet]]. */
 @RunWith(classOf[JUnitRunner])
 class TExtHashSetTest
-  extends Suite
+  extends Spec
   with    ShouldMatchers
 {
   import Data._

--- a/dot/src/test/scala/scalax/collection/io/dot/TExport.scala
+++ b/dot/src/test/scala/scalax/collection/io/dot/TExport.scala
@@ -4,7 +4,7 @@ package io.dot
 import language.{existentials, implicitConversions}
 import scala.collection.SortedMap
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
 
@@ -17,7 +17,7 @@ import org.junit.runner.RunWith
 
 /** Tests [[ArraySet]]. */
 @RunWith(classOf[JUnitRunner])
-class TExportTest extends Suite with ShouldMatchers {
+class TExportTest extends Spec with ShouldMatchers {
   def test_Wikipedia {
     // example from http://en.wikipedia.org/wiki/DOT_language
     implicit def toLDiEdge[N](diEdge: DiEdge[N]) = LDiEdge(diEdge._1, diEdge._2)("")

--- a/json/src/test/scala/demo/TJsonDemo.scala
+++ b/json/src/test/scala/demo/TJsonDemo.scala
@@ -1,6 +1,6 @@
 package demo
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Suites
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith
 
 @RunWith(classOf[JUnitRunner])
 class TJsonDemoTest
-	extends	Suite
+	extends	Spec
 	with	ShouldMatchers
 {
   val (programming, inDepth) = (

--- a/json/src/test/scala/scalax/collection/io/json/TCustomEdge.scala
+++ b/json/src/test/scala/scalax/collection/io/json/TCustomEdge.scala
@@ -2,7 +2,7 @@ package scalax.collection.io.json
 
 import language.higherKinds
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Suites
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
@@ -38,7 +38,7 @@ class TCustomEdgeRootTest
  */
 class TCustomEdge[CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: GraphCoreCompanion[CC] with GraphCoreCompanion[CC])
-	extends	Suite
+	extends	Spec
 	with	ShouldMatchers
 {
   val jsonText = """

--- a/json/src/test/scala/scalax/collection/io/json/TDefaultSerialization.scala
+++ b/json/src/test/scala/scalax/collection/io/json/TDefaultSerialization.scala
@@ -2,7 +2,7 @@ package scalax.collection.io.json
 
 import language.higherKinds
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Suites
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
@@ -34,7 +34,7 @@ class TDefaultSerializationRootTest
  */
 class TDefaultSerialization[CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: GraphCoreCompanion[CC] with GraphCoreCompanion[CC])
-	extends	Suite
+	extends	Spec
 	with	ShouldMatchers
 {
   object Fixture {

--- a/json/src/test/scala/scalax/collection/io/json/TJson.scala
+++ b/json/src/test/scala/scalax/collection/io/json/TJson.scala
@@ -2,7 +2,7 @@ package scalax.collection.io.json
 
 import language.higherKinds
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.Suites
 import org.scalatest.Informer
 import org.scalatest.matchers.ShouldMatchers
@@ -36,7 +36,7 @@ class TJsonRootTest
  */
 class TJson[CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: GraphCoreCompanion[CC] with GraphCoreCompanion[CC])
-	extends	Suite
+	extends	Spec
 	with	ShouldMatchers
 {
   object FixtureMixed {

--- a/json/src/test/scala/scalax/collection/io/json/serializer/TGraphSerializer.scala
+++ b/json/src/test/scala/scalax/collection/io/json/serializer/TGraphSerializer.scala
@@ -5,7 +5,7 @@ import language.higherKinds
 
 import net.liftweb.json._
 
-import org.scalatest.{Suite, Suites}
+import org.scalatest.{Spec, Suites}
 import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
@@ -28,7 +28,7 @@ class TGraphSerializerRootTest
  */
 class TGraphSerializer[CC[N,E[X] <: EdgeLikeIn[X]] <: Graph[N,E] with GraphLike[N,E,CC]]
     (val factory: GraphCoreCompanion[CC] with GraphCoreCompanion[CC])
-    extends Suite
+    extends Spec
     with ShouldMatchers {
 
   object GraphFixture {

--- a/misc/src/test/scala/scalax/collection/centrality/TKatz.scala
+++ b/misc/src/test/scala/scalax/collection/centrality/TKatz.scala
@@ -1,6 +1,6 @@
 package scalax.collection.centrality
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.matchers.ShouldMatchers
 
 import scalax.collection.GraphEdge._
@@ -11,7 +11,7 @@ import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 
 @RunWith(classOf[JUnitRunner])
-class TKatzTest extends Suite with ShouldMatchers {
+class TKatzTest extends Spec with ShouldMatchers {
 
   def test_Wikipedia {
     val ( kim,  pria,  sri,  jose,  diego,  agneta,  aziz,  bob,  john,  jane,  samantha) =

--- a/misc/src/test/scala/scalax/collection/rdf/TTripleDiEdge.scala
+++ b/misc/src/test/scala/scalax/collection/rdf/TTripleDiEdge.scala
@@ -1,7 +1,7 @@
 package scalax.collection
 package rdf
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.matchers.ShouldMatchers
 
 import org.scalatest.junit.JUnitRunner
@@ -13,7 +13,7 @@ import org.junit.runner.RunWith
  *  @author Peter Empen
  */
 @RunWith(classOf[JUnitRunner])
-class TTripleDiEdge extends Suite with ShouldMatchers {
+class TTripleDiEdge extends Spec with ShouldMatchers {
 
   type Triple[N] = TripleDiEdge[N]
   val Triple = TripleDiEdge

--- a/misc/src/test/scala/scalax/collection/rdf/TTripleDiHyperEdge.scala
+++ b/misc/src/test/scala/scalax/collection/rdf/TTripleDiHyperEdge.scala
@@ -1,7 +1,7 @@
 package scalax.collection
 package rdf
 
-import org.scalatest.Suite
+import org.scalatest.Spec
 import org.scalatest.matchers.ShouldMatchers
 
 import org.scalatest.junit.JUnitRunner
@@ -13,7 +13,7 @@ import org.junit.runner.RunWith
  *  @author Peter Empen
  */
 @RunWith(classOf[JUnitRunner])
-class TTripleDiHyperEdge extends Suite with ShouldMatchers {
+class TTripleDiHyperEdge extends Spec with ShouldMatchers {
 
   type Triple[N] = TripleDiHyperEdge[N]
   val Triple = TripleDiHyperEdge


### PR DESCRIPTION
I performed some modifications to remove all those deprecation warnings that were shown when running tests.
