### PR TITLE
EqHashSetIterator no longer uses O(n) constructor.

### DIFF
--- a/core/src/main/scala/scalax/collection/mutable/EqHash.scala
+++ b/core/src/main/scala/scalax/collection/mutable/EqHash.scala
@@ -118,7 +118,7 @@ trait EqHash[A<:AnyRef, This <: EqHash[A,This]] {
   protected abstract class EqHashIterator[A] extends Iterator[A] {
     protected val tab = table
     private[this] val len = tab.length
-    private[this] var index = if (size != 0) 0 else len
+    private[this] var index = if (_size != 0) 0 else len
     private[this] var lastReturnedIndex = -1
     private[this] var indexValid = false
 


### PR DESCRIPTION
Fixes #51 

It may be nicer to refer to the `EqHashSet.size`, but since the `size` is shadowed internally as well and implementing it in an iterator is strange, simply reading the inner `_size` variable seemed the best solution.