### PR TITLE
Updates for lift-json_2.12-3.0.1

### DIFF
--- a/json/src/main/scala/scalax/collection/io/json/descriptor/NodeDescriptor.scala
+++ b/json/src/main/scala/scalax/collection/io/json/descriptor/NodeDescriptor.scala
@@ -60,9 +60,10 @@ object StringNodeDescriptor extends NodeDescriptor[String] {
           case JInt   (_) |
                JDouble(_) => fld.extract[String]
           case JBool  (b) => b.toString
-          case JArray (_) |
-               JObject(_) => "(" + mkString(fld.children) + ")"
-          case JField(n,v)=> "(" + n + "," + mkString(List(v)) + ")"
+          case JArray (_) => "(" + mkString(fld.children) + ")"
+          case JObject(obj) => val buf = new StringBuilder("(")
+                             obj.foldLeft(buf)((buf, o) => buf.append(o.name + "," + mkString(List(o.value))))
+                             buf.append(")").toString
           case JNull      => "Null"
           case JNothing   => "Nothing" 
         }

--- a/json/src/main/scala/scalax/collection/io/json/imp/Parser.scala
+++ b/json/src/main/scala/scalax/collection/io/json/imp/Parser.scala
@@ -47,6 +47,19 @@ object Parser {
       jsonAST:    JValue,
       descriptor: Descriptor[N]): Iterable[ElemList] =
   {
+      jsonAST match {
+        case JObject(fields) => parse(fields, descriptor)
+        case _ => Seq[ElemList]().toIterable
+      }
+  }
+
+
+
+
+  def parse[N,C <: EdgeCompanionBase[EdgeLike]](
+      jsonAST:    List[JField],
+      descriptor: Descriptor[N]): Iterable[ElemList] =
+  {
     (for (JField(name, values) <- jsonAST
          if descriptor.sectionIds contains name)
      yield {

--- a/json/src/main/scala/scalax/collection/io/json/imp/Stream.scala
+++ b/json/src/main/scala/scalax/collection/io/json/imp/Stream.scala
@@ -72,7 +72,7 @@ object Stream {
                 val params: WLEdgeParameters[L] =
                     d.extract(jsonEdge).asInstanceOf[WLEdgeParameters[L]]
                 d.edgeCompanion(lookupNode(params.n1), lookupNode(params.n2))(
-                                params.weight, params.label)
+                                params.weight, params.label).asInstanceOf[E[N]]
               }
             
           case d: LEdgeDescriptor[N,LUnDiEdge,LEdgeCompanion[LUnDiEdge],_] @unchecked with
@@ -84,7 +84,7 @@ object Stream {
                 val params: LEdgeParameters[L] =
                     d.extract(jsonEdge).asInstanceOf[LEdgeParameters[L]]
                 d.edgeCompanion(lookupNode(params.n1), lookupNode(params.n2))(
-                                params.label)
+                                params.label).asInstanceOf[E[N]]
               }
 
           case d: WEdgeDescriptor[N,WUnDiEdge,WEdgeCompanion[WUnDiEdge]] @unchecked with
@@ -95,7 +95,7 @@ object Stream {
                 val params: WEdgeParameters =
                     d.extract(jsonEdge).asInstanceOf[WEdgeParameters]
                 d.edgeCompanion(lookupNode(params.n1), lookupNode(params.n2))(
-                                params.weight)
+                                params.weight).asInstanceOf[E[N]]
               }
 
           case d: CEdgeDescriptor[N,CEdge,CEdgeCompanion[CEdge],_] @unchecked with
@@ -130,7 +130,7 @@ object Stream {
                 val params: WLHyperEdgeParameters[L] =
                     d.extract(jsonEdge).asInstanceOf[WLHyperEdgeParameters[L]]
                 d.edgeCompanion(params.nodeIds map lookupNode)(
-                                params.weight, params.label)(CollectionKind.from(params.endpointsKind))
+                                params.weight, params.label)(CollectionKind.from(params.endpointsKind)).asInstanceOf[E[N]]
               }
 
           case d: LHyperEdgeDescriptor[N,LHyperEdge,LHyperEdgeCompanion[LHyperEdge],_] @unchecked with
@@ -141,7 +141,7 @@ object Stream {
               buf += {
                 val params: LHyperEdgeParameters[L] =
                     d.extract(jsonEdge).asInstanceOf[LHyperEdgeParameters[L]]
-                d.edgeCompanion(params.nodeIds map lookupNode)(params.label)(CollectionKind.from(params.endpointsKind))
+                d.edgeCompanion(params.nodeIds map lookupNode)(params.label)(CollectionKind.from(params.endpointsKind)).asInstanceOf[E[N]]
               }
 
           case d: WHyperEdgeDescriptor[N,WHyperEdge,WHyperEdgeCompanion[WHyperEdge]] @unchecked with
@@ -151,7 +151,7 @@ object Stream {
               buf += {
                 val params: WHyperEdgeParameters =
                     d.extract(jsonEdge).asInstanceOf[WHyperEdgeParameters]
-                d.edgeCompanion(params.nodeIds map lookupNode)(params.weight)(CollectionKind.from(params.endpointsKind))                                
+                d.edgeCompanion(params.nodeIds map lookupNode)(params.weight)(CollectionKind.from(params.endpointsKind)).asInstanceOf[E[N]]
               }
 
           case d: CHyperEdgeDescriptor[N,CHyperEdge,CHyperEdgeCompanion[CHyperEdge],_] @unchecked with

--- a/project/GraphBuild.scala
+++ b/project/GraphBuild.scala
@@ -48,7 +48,7 @@ object GraphBuild extends Build {
     settings = defaultSettings ++ Seq(
       name      := "Graph JSON",
       version   := Version.json,
-      libraryDependencies += "net.liftweb" %% "lift-json" % "2.6.2"
+      libraryDependencies += "net.liftweb" %% "lift-json" % "3.0.1"
     )
   ) dependsOn (core)
 


### PR DESCRIPTION
Problem: Migration to scala-2.12 is blocked by changes made in the version of lift-json that is scala-2.12 compatible.

Solution: Change the version of lift-json to 3.0.1.  Change the code in scala-graph/json files so that JField is never pattern matched; it no longer has an apply method.