### PR TITLE
Remove procedure syntax and add scalafix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,9 @@ lazy val defaultSettings = Defaults.coreDefaultSettings ++ Seq(
   organization := "org.scala-graph",
   scalacOptions ++= Seq(
     "-Ywarn-unused:imports",
-    "-Yrangepos"
+    "-Yrangepos",
+    "-Xfuture",
+    "-deprecation",
   ),
   addCompilerPlugin(scalafixSemanticdb),
   Test / parallelExecution := false,

--- a/constrained/src/main/scala/scalax/collection/constrained/constraints/Acyclic.scala
+++ b/constrained/src/main/scala/scalax/collection/constrained/constraints/Acyclic.scala
@@ -27,13 +27,12 @@ class Acyclic[N, E[X] <: EdgeLikeIn[X], G <: Graph[N, E]](override val self: G) 
       val isUndirected       = edge.isUndirected
       val checkFrom, checkTo = MutableSet.empty[self.NodeT]
       def find(n: N)         = self find n
-      def add1(n: N) {
+      def add1(n: N): Unit =
         find(n) map { inner =>
           checkFrom += inner
           if (isUndirected) checkTo += inner
         }
-      }
-      def add2(toSet: MutableSet[self.NodeT], n: N, nUndi: N) {
+      def add2(toSet: MutableSet[self.NodeT], n: N, nUndi: N): Unit = {
         find(n) map (inner => toSet += inner)
         find(nUndi) map { inner =>
           if (isUndirected) toSet += inner

--- a/constrained/src/main/scala/scalax/collection/constrained/immutable/AdjacencyListGraph.scala
+++ b/constrained/src/main/scala/scalax/collection/constrained/immutable/AdjacencyListGraph.scala
@@ -18,9 +18,8 @@ trait AdjacencyListGraph[
 
   protected type Config <: GraphConfig with GenConstrainedConfig with AdjacencyListArrayConfig
 
-  override protected def initialize(nodes: Traversable[N], edges: Traversable[E[N]]) {
+  override protected def initialize(nodes: Traversable[N], edges: Traversable[E[N]]): Unit =
     withoutChecks { super.initialize(nodes, edges) }
-  }
 
   /** generic constrained addition */
   protected def checkedAdd(contained: => Boolean,

--- a/constrained/src/test/scala/scalax/collection/constrained/TConstrained.scala
+++ b/constrained/src/test/scala/scalax/collection/constrained/TConstrained.scala
@@ -27,7 +27,7 @@ class TConstrainedMutable extends RefSpec with Matchers {
 
   object `constrains work as expected using mutable operations` {
 
-    def `when constraining Int nodes to even numbers` {
+    def `when constraining Int nodes to even numbers`: Unit = {
       implicit val config: Config = UserConstraints.EvenNode
       val g                       = Graph[Int, Nothing](1)
 
@@ -38,7 +38,7 @@ class TConstrainedMutable extends RefSpec with Matchers {
       (g ++= List(2, 4, 6)) should have size 3
     }
 
-    def `when constraining nodes to have a minimum degree` {
+    def `when constraining nodes to have a minimum degree`: Unit = {
       import UserConstraints.{MinDegreeException, MinDegree_2}
 
       implicit val config: Config                        = MinDegree_2
@@ -54,7 +54,7 @@ class TConstrainedMutable extends RefSpec with Matchers {
       shouldThrowExceptionAndLeaveGraphUnchanged(g)(_ --= List(3))
     }
 
-    def `when postSubtract fails` {
+    def `when postSubtract fails`: Unit = {
       implicit val config: Config                              = UserConstraints.AlwaysFailingPostSubtract
       implicit val expectedException: IllegalArgumentException = new IllegalArgumentException
 
@@ -67,7 +67,7 @@ class TConstrainedMutable extends RefSpec with Matchers {
       shouldThrowExceptionAndLeaveGraphUnchanged(g)(_ --= List(1 ~ 2, 2 ~ 3))
     }
 
-    def `when postAdd fails` {
+    def `when postAdd fails`: Unit = {
       implicit val config: Config                              = UserConstraints.FailingPostAdd
       implicit val expectedException: IllegalArgumentException = new IllegalArgumentException
 
@@ -80,7 +80,7 @@ class TConstrainedMutable extends RefSpec with Matchers {
       shouldThrowExceptionAndLeaveGraphUnchanged(g)(_ ++= List(1 ~ 5, 5 ~ 6, 6 ~ 2))
     }
 
-    def `when cloning a graph` {
+    def `when cloning a graph`: Unit = {
       implicit val config: Config = UserConstraints.AlwaysFailingPreAdd
 
       val g = Graph[Int, UnDiEdge](1 ~ 2, 2 ~ 3)
@@ -105,7 +105,7 @@ class TConstrained[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N,
 
   object `constrains take effect` {
 
-    def `when constraining Int nodes to even numbers` {
+    def `when constraining Int nodes to even numbers`: Unit = {
       implicit val config: Config = UserConstraints.EvenNode
       val g                       = factory[Int, Nothing](1, 2, 3, 4)
       g should be('isEmpty)
@@ -115,7 +115,7 @@ class TConstrained[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N,
       (g ++ List[OuterNode[Int]](2, 4, 6)) should have size 3
     }
 
-    def `when constraining nodes to have a minimum degree` {
+    def `when constraining nodes to have a minimum degree`: Unit = {
       import UserConstraints.{MinDegreeException, MinDegree_2}
       implicit val config: Config = MinDegree_2
 
@@ -143,7 +143,7 @@ class TConstrained[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N,
 
   object `constraints may` {
 
-    def `be defined to throw exceptions on constraint violations` {
+    def `be defined to throw exceptions on constraint violations`: Unit = {
       implicit val config: Config = UserConstraints.EvenNodeByException
       an[IllegalArgumentException] should be thrownBy { factory[Int, Nothing](1, 2, 3, 4) }
 
@@ -157,7 +157,7 @@ class TConstrained[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N,
       (g ++ List[OuterNode[Int]](2, 4, 6)) should have size 3
     }
 
-    def `be combined` {
+    def `be combined`: Unit = {
       import UserConstraints._
       {
         implicit val config: Config = EvenNode && EvenNode

--- a/constrained/src/test/scala/scalax/collection/constrained/constraints/TAcyclic.scala
+++ b/constrained/src/test/scala/scalax/collection/constrained/constraints/TAcyclic.scala
@@ -26,7 +26,7 @@ class TAcyclicMutable extends RefSpec with Matchers {
   import AcyclicWithException._
 
   object `The 'Acyclic' constraint works fine with` {
-    def `directed mutable graphs` {
+    def `directed mutable graphs`: Unit = {
       implicit val config: Config = Acyclic
       val g                       = Graph(1 ~> 2, 2 ~> 3)
       a[CycleException] should be thrownBy { g += 3 ~> 1 }
@@ -46,17 +46,17 @@ class TAcyclic[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, 
   implicit val config: Config = Acyclic
 
   object `The 'Acyclic' constraint works fine with` {
-    def `directed graphs` {
+    def `directed graphs`: Unit = {
       val g = factory(1 ~> 2, 2 ~> 3)
       a[CycleException] should be thrownBy { g + 3 ~> 1 }
       g + 3 ~> 4 should have size (7)
     }
-    def `directed hypergraphs` {
+    def `directed hypergraphs`: Unit = {
       val g = factory[Int, HyperEdge](1 ~> 2 ~> 3, 2 ~> 3 ~> 4)
       a[CycleException] should be thrownBy { g + 4 ~> 2 }
       g + 1 ~> 4 should have size (7)
     }
-    def `undirected graphs` {
+    def `undirected graphs`: Unit = {
       val g = factory(1 ~ 2, 2 ~ 3)
       a[CycleException] should be thrownBy { g + 3 ~ 1 }
       g + 3 ~ 4 should have size (7)
@@ -68,7 +68,7 @@ class TAcyclic[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, 
 //      a [CycleException] should be thrownBy { g + 1~4 }
 //      g + 1~6 should have size (9)
 //    }
-    def `self loops #76` {
+    def `self loops #76`: Unit = {
       a[CycleException] should be thrownBy { factory(1 ~> 1) }
       a[CycleException] should be thrownBy { factory[Int, DiEdge]() + 1 ~> 1 }
     }

--- a/constrained/src/test/scala/scalax/collection/constrained/constraints/TConnected.scala
+++ b/constrained/src/test/scala/scalax/collection/constrained/constraints/TConnected.scala
@@ -29,7 +29,7 @@ class TConnectedMutable extends RefSpec with Matchers {
   implicit val config: Config = Connected
 
   object `The 'Connected' constraint works fine with mutable graphs on` {
-    def `adding nodes or edges` {
+    def `adding nodes or edges`: Unit = {
       val init    = Seq(1 ~> 2, 2 ~> 3)
       val simpleG = SimpleGraph(init: _*)
       val g       = Graph(init: _*)
@@ -44,7 +44,7 @@ class TConnectedMutable extends RefSpec with Matchers {
       val newElems = Seq(4 ~> 5, 5 ~> 6, 6 ~> 1)
       (g ++= newElems) should be(simpleG ++= newElems)
     }
-    def `substracting nodes or edges` {
+    def `substracting nodes or edges`: Unit = {
       val (e1, e2, e3) = (1 ~ 2, 2 ~ 3, 3 ~ 4)
       val init         = Seq(e1, e2, e3)
       val simpleG      = SimpleGraph(init: _*)
@@ -77,13 +77,13 @@ class TConnected[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E
   info("factory = " + factory.getClass)
 
   object `The 'Connected' constraint works fine with graphs on` {
-    def `creation ` {
+    def `creation ` : Unit = {
       val g1 = Graph(1 ~> 2, 2 ~> 3)
       g1 should have size (5)
       val g2 = Graph(1 ~> 2, 3 ~> 4)
       g2 should have size (0)
     }
-    def `adding nodes or edges` {
+    def `adding nodes or edges`: Unit = {
       val init    = Seq(1 ~> 2, 2 ~> 3)
       val simpleG = SimpleGraph(init: _*)
       val g       = Graph(init: _*)
@@ -98,7 +98,7 @@ class TConnected[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E
       val newElems = Seq(4 ~> 5, 5 ~> 6, 6 ~> 1)
       g ++ newElems should be(simpleG ++ newElems)
     }
-    def `substracting nodes or edges` {
+    def `substracting nodes or edges`: Unit = {
       val (e1, e2, e3) = (1 ~ 2, 2 ~ 3, 3 ~ 4)
       val init         = Seq(e1, e2, e3)
       val simpleG      = SimpleGraph(init: _*)

--- a/core/src/main/scala/scalax/collection/GraphBase.scala
+++ b/core/src/main/scala/scalax/collection/GraphBase.scala
@@ -39,7 +39,7 @@ trait GraphBase[N, E[X] <: EdgeLikeIn[X]] extends Serializable { selfGraph =>
     * @param nodes $INNODES
     * @param edges $INEDGES
     */
-  protected def initialize(nodes: Traversable[N], edges: Traversable[E[N]]) {
+  protected def initialize(nodes: Traversable[N], edges: Traversable[E[N]]): Unit = {
     this.nodes.initialize(nodes, edges)
     this.edges.initialize(edges)
   }
@@ -185,7 +185,7 @@ trait GraphBase[N, E[X] <: EdgeLikeIn[X]] extends Serializable { selfGraph =>
     /** Whether this node has any predecessors. */
     def hasPredecessors: Boolean
 
-    protected[collection] def addDiPredecessors(edge: EdgeT, add: (NodeT) => Unit)
+    protected[collection] def addDiPredecessors(edge: EdgeT, add: (NodeT) => Unit): Unit
 
     /** Synonym for `diPredecessors`. */
     @inline final def inNeighbors = diPredecessors
@@ -199,7 +199,7 @@ trait GraphBase[N, E[X] <: EdgeLikeIn[X]] extends Serializable { selfGraph =>
       * @return set of all neighbors.
       */
     def neighbors: Set[NodeT]
-    protected[collection] def addNeighbors(edge: EdgeT, add: (NodeT) => Unit)
+    protected[collection] def addNeighbors(edge: EdgeT, add: (NodeT) => Unit): Unit
 
     /** Synonym for `neighbors`. */
     @inline final def ~| = neighbors
@@ -331,15 +331,12 @@ trait GraphBase[N, E[X] <: EdgeLikeIn[X]] extends Serializable { selfGraph =>
     def apply(node: N)    = newNode(node)
     def unapply(n: NodeT) = Some(n)
 
-    @inline final protected[collection] def addDiSuccessors(node: NodeT, edge: EdgeT, add: (NodeT) => Unit) {
+    @inline final protected[collection] def addDiSuccessors(node: NodeT, edge: EdgeT, add: (NodeT) => Unit): Unit =
       node.addDiSuccessors(edge, add)
-    }
-    @inline final protected[collection] def addDiPredecessors(node: NodeT, edge: EdgeT, add: (NodeT) => Unit) {
+    @inline final protected[collection] def addDiPredecessors(node: NodeT, edge: EdgeT, add: (NodeT) => Unit): Unit =
       node.addDiPredecessors(edge, add)
-    }
-    @inline final protected[collection] def addNeighbors(node: NodeT, edge: EdgeT, add: (NodeT) => Unit) {
+    @inline final protected[collection] def addNeighbors(node: NodeT, edge: EdgeT, add: (NodeT) => Unit): Unit =
       node.addNeighbors(edge, add)
-    }
 
     /** Allows to call methods of N directly on Node instances.
       *

--- a/core/src/main/scala/scalax/collection/GraphEdge.scala
+++ b/core/src/main/scala/scalax/collection/GraphEdge.scala
@@ -104,7 +104,7 @@ object GraphEdge {
       *  @throws EdgeException if any of the basic validations or of eventually
       *  supplied additional validations fails.
       */
-    final protected def validate {
+    final protected def validate: Unit = {
       nodes match {
         case r: AnyRef if r eq null =>
           throw new EdgeException(s"null node in: $toString")

--- a/core/src/main/scala/scalax/collection/State.scala
+++ b/core/src/main/scala/scalax/collection/State.scala
@@ -42,7 +42,7 @@ protected trait State[N, E[X] <: EdgeLikeIn[X]] {
 
   /** Avoid calling this directly, prefer `withHandle` instead. */
   protected def nextHandle: Handle = monitor.synchronized {
-    def clearNodes(hasDirtyExt: Boolean) {
+    def clearNodes(hasDirtyExt: Boolean): Unit = {
       clearNodeStates(dirty.flags, if (hasDirtyExt) dirty.flagsExt else null)
       dirty.flags = 0
       if (hasDirtyExt) dirty.flagsExt.clear
@@ -129,7 +129,7 @@ protected trait State[N, E[X] <: EdgeLikeIn[X]] {
     @inline final protected[collection] def visited(implicit handle: Handle): Boolean =
       bit(handle)
 
-    @inline final protected[collection] def bit_=[T](isSet: Boolean)(implicit handle: Handle) {
+    @inline final protected[collection] def bit_=[T](isSet: Boolean)(implicit handle: Handle): Unit =
       monitor.synchronized {
         if (handle.index == singleWord)
           flags =
@@ -137,15 +137,13 @@ protected trait State[N, E[X] <: EdgeLikeIn[X]] {
             else flags & ~handle.mask
         else withFlagsExt(_.update(handle.index, handle.mask, isSet))
       }
-    }
 
     /** Sets this node to `visited` with respect to to `handle`. */
-    @inline final protected[collection] def visited_=(visited: Boolean)(implicit handle: Handle) {
+    @inline final protected[collection] def visited_=(visited: Boolean)(implicit handle: Handle): Unit =
       bit_=(visited)(handle)
-    }
   }
 
-  protected def clearNodeStates(flags: FlagWord, flagsExt: ExtBitSet) {
+  protected def clearNodeStates(flags: FlagWord, flagsExt: ExtBitSet): Unit = {
     val clear      = ~flags
     val doClearExt = flagsExt != null
     val clearExt   = if (doClearExt) ~flagsExt else null
@@ -187,14 +185,13 @@ object State {
         flagsExt(handle.index, handle.mask)
 
     /** Sets `store` to `isSet` with respect to `handle`. */
-    def update(handle: Handle, isSet: Boolean) {
+    def update(handle: Handle, isSet: Boolean): Unit =
       if (handle.index == singleWord)
         flags =
           if (isSet) flags | handle.mask
           else flags & ~handle.mask
       else
         flagsExt(handle.index, handle.mask) = isSet
-    }
   }
 
   /** Dumps the state flags of a `node`. */

--- a/core/src/main/scala/scalax/collection/TraverserImpl.scala
+++ b/core/src/main/scala/scalax/collection/TraverserImpl.scala
@@ -322,7 +322,7 @@ trait TraverserImpl[N, E[X] <: EdgeLikeIn[X]] {
               )
           }
 
-          def relax(pred: NodeT, succ: NodeT) {
+          def relax(pred: NodeT, succ: NodeT): Unit = {
             val cost = dest(pred) +
               weight(pred.outgoingTo(succ).withFilter(subgraphEdges(_)).min)
             if (!dest.isDefinedAt(succ) || cost < dest(succ)) {
@@ -332,7 +332,7 @@ trait TraverserImpl[N, E[X] <: EdgeLikeIn[X]] {
           }
 
           var nodeCnt = 0
-          @tailrec def rec(pq: PriorityQueue[PrioQueueElem]) {
+          @tailrec def rec(pq: PriorityQueue[PrioQueueElem]): Unit =
             if (pq.nonEmpty && (pq.head.node ne potentialSuccessor)) {
               val PrioQueueElem(node, cumWeight, depth) = pq.dequeue
               if (!node.visited) {
@@ -341,12 +341,11 @@ trait TraverserImpl[N, E[X] <: EdgeLikeIn[X]] {
                   else sortedAdjacentNodes(node, cumWeight, depth + 1)
                 pq ++= ordNodes
 
-                @tailrec def loop(pq2: PriorityQueue[PrioQueueElem]) {
+                @tailrec def loop(pq2: PriorityQueue[PrioQueueElem]): Unit =
                   if (pq2.nonEmpty) {
                     relax(node, pq2.dequeue.node)
                     loop(pq2)
                   }
-                }
                 loop(ordNodes)
 
                 node.visited = true
@@ -362,7 +361,6 @@ trait TraverserImpl[N, E[X] <: EdgeLikeIn[X]] {
               }
               rec(pq)
             }
-          }
           rec(qNodes)
           def traverseMapNodes(map: MMap[NodeT, NodeT]): Option[Path] =
             map
@@ -435,7 +433,7 @@ trait TraverserImpl[N, E[X] <: EdgeLikeIn[X]] {
           val path: Stack[Element]  = Stack()
           var res: Option[NodeT]    = None
           var nodeCnt               = 0
-          @tailrec def loop {
+          @tailrec def loop: Unit =
             if (stack.nonEmpty) {
               val popped @ Element(current, depth, cumWeight) = stack.pop
               if (depth > 0)
@@ -484,7 +482,6 @@ trait TraverserImpl[N, E[X] <: EdgeLikeIn[X]] {
                 }
               }
             }
-          }
           loop
           if (doNodeUpVisitor) path foreach (e => nodeUpVisitor(e.node))
           (res, path)
@@ -599,15 +596,15 @@ trait TraverserImpl[N, E[X] <: EdgeLikeIn[X]] {
           val isDiGraph    = thisGraph.isDirected
           val isMixedGraph = thisGraph.isMixed
 
-          def isWhite(node: NodeT)  = nonVisited(node)
-          def isGray(node: NodeT)   = isVisited(node) && !(node bit blackHandle)
-          def isBlack(node: NodeT)  = node bit blackHandle
-          def nonBlack(node: NodeT) = !isBlack(node)
-          def setGray(node: NodeT) { node.visited = true }
-          def setBlack(node: NodeT) { node.bit_=(isSet = true)(blackHandle) }
+          def isWhite(node: NodeT)        = nonVisited(node)
+          def isGray(node: NodeT)         = isVisited(node) && !(node bit blackHandle)
+          def isBlack(node: NodeT)        = node bit blackHandle
+          def nonBlack(node: NodeT)       = !isBlack(node)
+          def setGray(node: NodeT): Unit  = node.visited = true
+          def setBlack(node: NodeT): Unit = node.bit_=(isSet = true)(blackHandle)
 
-          def onNodeDown(node: NodeT) { setGray(node) }
-          def onNodeUp(node: NodeT) { setBlack(node) }
+          def onNodeDown(node: NodeT): Unit = setGray(node)
+          def onNodeUp(node: NodeT): Unit   = setBlack(node)
 
           def isVisited(node: NodeT)  = node.visited
           def nonVisited(node: NodeT) = !isVisited(node)

--- a/core/src/main/scala/scalax/collection/generator/RandomGraph.scala
+++ b/core/src/main/scala/scalax/collection/generator/RandomGraph.scala
@@ -42,9 +42,9 @@ abstract class RandomGraph[N, E[X] <: EdgeLikeIn[X], G[X, Y[Z] <: EdgeLikeIn[Z]]
 
   implicit val graphConfig: graphCompanion.Config
 
-  protected val doTrace = false
-  protected def trace(str: => String) { if (doTrace) print(str) }
-  protected def traceln(str: => String) { if (doTrace) println(str) }
+  protected val doTrace                       = false
+  protected def trace(str: => String): Unit   = if (doTrace) print(str)
+  protected def traceln(str: => String): Unit = if (doTrace) println(str)
 
   final protected[RandomGraph] class DefaultWeightFactory {
     private[this] var weightCount = 0L
@@ -143,7 +143,7 @@ abstract class RandomGraph[N, E[X] <: EdgeLikeIn[X], G[X, Y[Z] <: EdgeLikeIn[Z]]
     def mayFinish: Boolean = active.toFloat / order < 0.5
 
     private[this] var idx = 0
-    def add(node: N, degree: Int) {
+    def add(node: N, degree: Int): Unit = {
       nodes(idx) = node
       degrees(idx) = degree
       idx += 1

--- a/core/src/main/scala/scalax/collection/generic/GroupIterator.scala
+++ b/core/src/main/scala/scalax/collection/generic/GroupIterator.scala
@@ -19,7 +19,7 @@ trait GroupIterator[A] extends Iterator[A] {
 
   /** Called on the first time when `hasNext` of the innermost iterator returns
     * `false`. The default implementation does nothing. */
-  def onExit {}
+  def onExit: Unit = {}
 
   sealed protected trait LevelIterator[A] extends Iterator[A] {
 
@@ -87,7 +87,7 @@ trait GroupIterator[A] extends Iterator[A] {
     * grouped by countries, the implementation of this trait will correspond to the
     * city iterator. */
   trait InnermostIterator[A] extends LevelIterator[A] with InnermostIteratorDecl {
-    final protected[GroupIterator] def init {
+    final protected[GroupIterator] def init: Unit = {
       onOuterChange(outer.current)
       optHasNext = None
     }

--- a/core/src/main/scala/scalax/collection/immutable/AdjacencyListBase.scala
+++ b/core/src/main/scala/scalax/collection/immutable/AdjacencyListBase.scala
@@ -102,9 +102,8 @@ trait AdjacencyListBase[
 
     final def hasPredecessors: Boolean = edges exists (_.hasSource((n: NodeT) => n ne this))
 
-    final protected[collection] def addDiPredecessors(edge: EdgeT, add: (NodeT) => Unit) {
+    final protected[collection] def addDiPredecessors(edge: EdgeT, add: (NodeT) => Unit): Unit =
       edge withSources (n => if (n ne this) add(n))
-    }
 
     final def neighbors: Set[NodeT] = {
       val m = new EqHashSet[NodeT](edges.size)
@@ -112,9 +111,8 @@ trait AdjacencyListBase[
       new EqSetFacade(m)
     }
 
-    final protected[collection] def addNeighbors(edge: EdgeT, add: (NodeT) => Unit) {
+    final protected[collection] def addNeighbors(edge: EdgeT, add: (NodeT) => Unit): Unit =
       edge foreach (n => if (n ne this) add(n))
-    }
 
     final def outgoing = edges withSetFilter (e =>
       if (e.isDirected) e.hasSource((_: NodeT) eq this)
@@ -281,9 +279,8 @@ trait AdjacencyListBase[
     object Inner extends InnermostIterator[EdgeT] {
       protected type I = EdgeT
       protected var iterator: Iterator[I] = _
-      protected def onOuterChange(newOuter: OuterElm) {
+      protected def onOuterChange(newOuter: OuterElm): Unit =
         iterator = newOuter.edges.filter(_.edge._1 == newOuter).iterator
-      }
       protected def elmToCurrent(elm: EdgeT) = elm
 
       protected type OuterElm = NodeT

--- a/core/src/main/scala/scalax/collection/immutable/AdjacencyListGraph.scala
+++ b/core/src/main/scala/scalax/collection/immutable/AdjacencyListGraph.scala
@@ -29,7 +29,7 @@ trait AdjacencyListGraph[
 
   type NodeSetT = NodeSet
   class NodeSet extends super.NodeSet {
-    @inline final override protected def minus(node: NodeT) { coll -= node }
+    @inline final override protected def minus(node: NodeT): Unit = coll -= node
     def +(node: NodeT) =
       if (coll contains node) this
       else { val c = copy; c.coll += node; c }
@@ -64,9 +64,9 @@ trait AdjacencyListGraph[
       this
     }
 
-    @inline final protected[immutable] def addEdge(edge: EdgeT) { +=(edge) }
-    @inline final def +(edge: EdgeT): Set[EdgeT] = toSet + edge
-    @inline final def -(edge: EdgeT): Set[EdgeT] = toSet - edge
+    @inline final protected[immutable] def addEdge(edge: EdgeT): Unit = +=(edge)
+    @inline final def +(edge: EdgeT): Set[EdgeT]                      = toSet + edge
+    @inline final def -(edge: EdgeT): Set[EdgeT]                      = toSet - edge
 
     @inline final override lazy val maxArity        = super.maxArity
     @inline final override lazy val hasAnyMultiEdge = super.hasAnyMultiEdge

--- a/core/src/main/scala/scalax/collection/mutable/AdjacencyListGraph.scala
+++ b/core/src/main/scala/scalax/collection/mutable/AdjacencyListGraph.scala
@@ -38,7 +38,7 @@ trait AdjacencyListGraph[
       inserted
     }
 
-    final protected def addDiSuccOrHook(edge: EdgeT) {
+    final protected def addDiSuccOrHook(edge: EdgeT): Unit = {
       if (edge.matches(nodeEqThis, nodeEqThis) && aHook.isEmpty)
         _aHook = Some(this -> edge)
       addDiSuccessors(edge, (n: NodeT) => diSucc put (n, edge))

--- a/core/src/main/scala/scalax/collection/mutable/EqHash.scala
+++ b/core/src/main/scala/scalax/collection/mutable/EqHash.scala
@@ -19,7 +19,7 @@ trait EqHash[A <: AnyRef, This <: EqHash[A, This]] {
     (length / 3, new Array[AnyRef](length))
   }
 
-  def from(other: This) {
+  def from(other: This): Unit = {
     threshold = other.threshold
     table = other.table.clone
     _size = other.size
@@ -67,12 +67,12 @@ trait EqHash[A <: AnyRef, This <: EqHash[A, This]] {
     index(maskedKey, hash(maskedKey, len, step - 1), len)
   }
 
-  override def clear {
+  override def clear: Unit = {
     java.util.Arrays.fill(table, null)
     _size = 0
   }
 
-  protected def resize {
+  protected def resize: Unit = {
     val oldTable  = table
     val oldLength = oldTable.length
     val newLength = 2 * oldLength
@@ -90,7 +90,7 @@ trait EqHash[A <: AnyRef, This <: EqHash[A, This]] {
 
   protected def move(oldTable: Array[AnyRef], oldLength: Int, newTable: Array[AnyRef], newLength: Int): Unit
 
-  final protected def closeDeletion(index: Int) {
+  final protected def closeDeletion(index: Int): Unit = {
     // Knuth Section 6.4 Algorithm R
     val tab  = table
     val len  = tab.length

--- a/core/src/main/scala/scalax/collection/mutable/ExtBitSet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/ExtBitSet.scala
@@ -33,16 +33,15 @@ final protected[collection] class ExtBitSet(words: Array[Long]) extends BitSet(w
 
   @inline def apply(h: Handle): Boolean = apply(h.index, h.mask)
 
-  def update(idx: Int, mask: Long, isSet: Boolean) {
+  def update(idx: Int, mask: Long, isSet: Boolean): Unit =
     if (isSet) {
       val word =
         if (idx >= nwords) { expand(idx); 0L } else elems(idx)
       elems(idx) = word | mask
     } else if (idx < nwords)
       elems(idx) = elems(idx) & ~mask
-  }
 
-  @inline def update(h: Handle, isSet: Boolean) { update(h.index, h.mask, isSet) }
+  @inline def update(h: Handle, isSet: Boolean): Unit = update(h.index, h.mask, isSet)
 
   def unary_~ : ExtBitSet = {
     val newBits = new ExtBitSet(nwords)
@@ -83,7 +82,7 @@ final protected[collection] class ExtBitSet(words: Array[Long]) extends BitSet(w
     None
   }
 
-  private def expand(mustHaveIdx: Int) {
+  private def expand(mustHaveIdx: Int): Unit = {
     var newlen = nwords
     while (mustHaveIdx >= newlen) newlen = newlen + incrWords
     val newElems = new Array[Long](newlen)

--- a/core/src/main/scala/scalax/collection/mutable/Graph.scala
+++ b/core/src/main/scala/scalax/collection/mutable/Graph.scala
@@ -31,14 +31,13 @@ abstract protected[collection] class BuilderImpl[
     }
   )
 
-  protected def add(elem: Param[N, E]) {
+  protected def add(elem: Param[N, E]): Unit =
     elem match {
       case n: OuterNode[N]               => nodes += n.value
       case n: InnerNodeParam[N]          => nodes += n.value
       case e: OuterEdge[N, E]            => edges += e.edge
       case e: InnerEdgeParam[N, E, _, E] => edges += e.asEdgeTProjection[N, E].toOuter
     }
-  }
 
   override def +=(elem: Param[N, E]): this.type = {
     add(elem)
@@ -51,7 +50,7 @@ abstract protected[collection] class BuilderImpl[
     this
   }
 
-  def clear() {
+  def clear(): Unit = {
     nodes.clear
     edges.clear
   }

--- a/core/src/main/scala/scalax/collection/mutable/SimpleArraySet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/SimpleArraySet.scala
@@ -32,7 +32,7 @@ final class SimpleArraySet[A](override val hints: ArraySet.Hints)
   private var arr: Array[A]                                = _
   private var hashSet: ExtHashSet[A]                       = _
 
-  private def initialize {
+  private def initialize: Unit = {
     val capacity = hints.nextCapacity(0)
     if (capacity == 0) hashSet = ExtHashSet.empty[A]
     else arr = new Array[AnyRef](capacity).asInstanceOf[Array[A]]
@@ -53,13 +53,12 @@ final class SimpleArraySet[A](override val hints: ArraySet.Hints)
     this
   }
 
-  protected def removeIndex(i: Int) {
+  protected def removeIndex(i: Int): Unit =
     if (i != -1) {
       if (i + 1 < nextFree)
         arraycopy(arr, i + 1, arr, i, nextFree - i - 1)
       nextFree -= 1
     }
-  }
 
   protected[collection] def +=!(elem: A): this.type = {
     if (isHash) hashSet add elem
@@ -92,21 +91,20 @@ final class SimpleArraySet[A](override val hints: ArraySet.Hints)
         }
       }
 
-  override def foreach[U](f: (A) => U) {
+  override def foreach[U](f: (A) => U): Unit =
     if (isHash) hashSet foreach f
     else {
       var i = 0
       while (i < nextFree) { f(arr(i)); i += 1 }
     }
-  }
 
-  final protected def resizeArray(fromCapacity: Int, toCapacity: Int) {
+  final protected def resizeArray(fromCapacity: Int, toCapacity: Int): Unit = {
     val newArr: Array[AnyRef] = new Array(toCapacity)
     arraycopy(arr, 0, newArr, 0, math.min(fromCapacity, toCapacity))
     arr = newArr.asInstanceOf[Array[A]]
   }
 
-  final protected def setToArray(set: Iterable[A], size: Int) {
+  final protected def setToArray(set: Iterable[A], size: Int): Unit = {
     arr = new Array[AnyRef](size).asInstanceOf[Array[A]]
     nextFree = 0
     set foreach { elem =>
@@ -116,7 +114,7 @@ final class SimpleArraySet[A](override val hints: ArraySet.Hints)
     hashSet = null
   }
 
-  def compact {
+  def compact: Unit =
     if (isHash) {
       val _size = size
       if (_size < hints.hashTableThreshold)
@@ -127,7 +125,6 @@ final class SimpleArraySet[A](override val hints: ArraySet.Hints)
                  case perc                => perc >= nextFree * 100 / capacity
                })
       resizeArray(capacity, nextFree)
-  }
 
   final protected def indexOf[B](elem: B, pred: (A, B) => Boolean): Int = {
     var i = 0

--- a/core/src/test/scala/custom/TExtByImplicit.scala
+++ b/core/src/test/scala/custom/TExtByImplicit.scala
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith
 @RunWith(classOf[JUnitRunner])
 class TExtByImplicitTest extends RefSpec with Matchers {
   object `graphs may be enriched` {
-    def `at graph level for any edge type` {
+    def `at graph level for any edge type`: Unit = {
 
       implicit final class ExtGraph[N, E[X] <: EdgeLikeIn[X]](val g: Graph[N, E]) {
         /* Set of all directed edges contained in g.
@@ -28,7 +28,7 @@ class TExtByImplicitTest extends RefSpec with Matchers {
       Graph(1 ~ 2, 2 ~> 3).diEdges should have size (1)
     }
 
-    def `at graph level restricted to directed graphs` {
+    def `at graph level restricted to directed graphs`: Unit = {
       /* Provide graph enrichment restricted to graphs with edges of type `DiEdgeLike` or edges derived from this type.
        */
       implicit final class ExtDiGraph[N, E[X] <: DiEdgeLikeIn[X]](val g: Graph[N, E]) {
@@ -45,7 +45,7 @@ class TExtByImplicitTest extends RefSpec with Matchers {
       // Graph(1~2).alwaysTrue
     }
 
-    def `at graph level for a specific edge type` {
+    def `at graph level for a specific edge type`: Unit = {
       /* Provide graph enrichment restricted to graphs with edges of type `UnDiEdge`.
        * Note that a lower bound must also be defined to exclude directed edges.
        */
@@ -63,7 +63,7 @@ class TExtByImplicitTest extends RefSpec with Matchers {
       // Graph(1~>2).alwaysTrue
     }
 
-    def `at node level` {
+    def `at node level`: Unit = {
       /* Provide node enrichment.
        * Note that this way of enrichment is not suitable for methods returning
        * inner nodes or inner edges.
@@ -88,7 +88,7 @@ class TExtByImplicitTest extends RefSpec with Matchers {
       (g get 3).outgoingWeights should be(5)
     }
 
-    def `at node level to return inner elements with easy consumption` {
+    def `at node level to return inner elements with easy consumption`: Unit = {
       /* Provide node enrichment also suitable for methods returning inner nodes.
        */
       implicit def toExtNode[N, E[X] <: EdgeLikeIn[X]](node: Graph[N, E]#NodeT)(implicit graph: Graph[N, E]) = {
@@ -105,7 +105,7 @@ class TExtByImplicitTest extends RefSpec with Matchers {
       incoming.map(_.shortestPathTo(g get 3)()) should be('isDefined)
     }
 
-    def `at node level to return inner elements with less easy consumption but the recommended way` {
+    def `at node level to return inner elements with less easy consumption but the recommended way`: Unit = {
       /* Provide node enrichment also suitable for methods returning inner nodes.
        * This is the recommended, type-safe way of extending nodes.
        */

--- a/core/src/test/scala/custom/TExtNode.scala
+++ b/core/src/test/scala/custom/TExtNode.scala
@@ -16,12 +16,12 @@ class TExtNodeTest extends RefSpec with Matchers {
 
   object `inner node enriched by 'helloSuccessors' works for` {
 
-    def `immutable graphs` {
+    def `immutable graphs`: Unit = {
       val g = Graph(1 ~ 2, 1 ~ 3)
       (g get 1 helloSuccessors) should be("Hello 2,3!")
     }
 
-    def `mutable graphs` {
+    def `mutable graphs`: Unit = {
       val g  = MutableGraph(1 ~ 2, 1 ~ 3)
       val n1 = g get 1
       (n1 helloSuccessors) should be("Hello 2,3!")

--- a/core/src/test/scala/custom/flight/TFlight.scala
+++ b/core/src/test/scala/custom/flight/TFlight.scala
@@ -32,7 +32,7 @@ class TFlight[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, C
   val flightNo   = "LH007"
 
   object `Custom edge 'Flight'` {
-    def `proper methods` {
+    def `proper methods`: Unit = {
       val outer = Flight(ham, gig, flightNo)
       given(factory(outer)) { g =>
         val e = g.edges.head
@@ -50,7 +50,7 @@ class TFlight[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, C
         e.## should not be (neFlight.##)
       }
     }
-    def `proper method shortcuts` {
+    def `proper method shortcuts`: Unit = {
       val outer = Flight(ham, gig, flightNo)
       given(factory(outer)) { _ =>
         ham ~> gig ## flightNo should be(outer)

--- a/core/src/test/scala/demo/TGraphTest.scala
+++ b/core/src/test/scala/demo/TGraphTest.scala
@@ -165,11 +165,10 @@ object TGraphTest extends App {
         implicit val arbitraryTinyGraph =
           GraphGen.tinyConnectedIntDi[Graph](Graph)
 
-        def `should conform to tiny metrics` {
+        def `should conform to tiny metrics`: Unit =
           forAll(arbitrary[IntDiGraph]) { g: IntDiGraph =>
             g.order should equal(GraphGen.TinyInt.order)
           }
-        }
       }
     }
   }

--- a/core/src/test/scala/demo/Traversing.scala
+++ b/core/src/test/scala/demo/Traversing.scala
@@ -39,7 +39,7 @@ final class TraversingTest extends RefSpec with Matchers {
   def n(outer: Int): g.NodeT = g get outer
 
   object `demonstraiting ` {
-    def `traversals for a result` {
+    def `traversals for a result`: Unit = {
       
       n(1) findSuccessor (_.outDegree >  3)              should be (None) 
       n(1) findSuccessor (_.outDegree >= 3)              should be (Some(3)) 
@@ -77,7 +77,7 @@ final class TraversingTest extends RefSpec with Matchers {
       pO2.map(_.nodes)             .get.toList should be (List(4, 5, 1, 2)) 
     }
   
-    def `cycle detection` {
+    def `cycle detection`: Unit = {
       val g = Graph(1~>2, 1~>3, 2~>3, 3~>4, 4~>2)
       val fc1 = g.findCycle
                                    fc1.get.sameElements(List(
@@ -93,7 +93,7 @@ c1 <- fc1
  c2 <- fc2} yield c1 sameAs c2      should be (true)
     }
     
-    def `ordered traversal` {
+    def `ordered traversal`: Unit = {
       val root = 1
       val g = Graph(root~>4 % 2, root~>2 % 5, root~>3 % 4,
                        3~>6 % 4,    3~>5 % 5,    3~>7 % 2)
@@ -104,7 +104,7 @@ c1 <- fc1
       traverser.toList             should be (List(1,2,3,4,5,6,7))
     }
     
-    def `traversers with fluent properties` {
+    def `traversers with fluent properties`: Unit = {
       val g = Graph(1~>2 % 1, 1~>3 % 2, 2~>3 % 3, 3~>4 % 1)
       val n1 = g get 1
       
@@ -124,7 +124,7 @@ c1 <- fc1
                                    1, 2, 3, 1~>3 % 2, 2~>3 % 3))
     }
     
-    def `DownUp traverser` {
+    def `DownUp traverser`: Unit = {
       import scala.collection.mutable.ArrayBuffer
   
       val root = "A"
@@ -141,7 +141,7 @@ c1 <- fc1
                                   be ("(A[B2][B1])"))
     }
   
-    def `extended traverser` {
+    def `extended traverser`: Unit = {
       val g = Graph(1 ~> 2, 1 ~> 3, 2 ~> 3, 3 ~> 4, 4 ~> 2)
   
       import g.ExtendedNodeVisitor
@@ -158,7 +158,7 @@ c1 <- fc1
         a._1 == b._1 && a._2 < b._2) should be (List((1,0), (2,1), (3,1), (4,2)))    
     }
     
-    def `cycle detection for side effect` {
+    def `cycle detection for side effect`: Unit = {
       val g = Graph(1~>2, 1~>3, 2~>3, 3~>4, 4~>2)
       
       var center: Option[g.NodeT] = None
@@ -172,7 +172,7 @@ c1 <- fc1
       center.get should be (2)
     }
   
-    def `weak component traverser` {
+    def `weak component traverser`: Unit = {
       val componentEdges = {
         def edges(i: Int) = List(i ~> (i + 1), i ~> (i + 2), (i + 1) ~> (i + 2))
         (edges(1), edges(5))
@@ -187,7 +187,7 @@ c1 <- fc1
       anyNode.weakComponent.nodes should have size componentEdges._1.size
     }
     
-    def `strong component traverser` {
+    def `strong component traverser`: Unit = {
       type G = Graph[Symbol,DiEdge]
       val sccExpected: (G, G) = (
           Graph('a ~> 'b, 'b ~> 'c, 'c ~> 'd, 'd ~> 'a, 'd ~> 'e, 'c ~> 'e, 'e ~> 'c),
@@ -202,7 +202,7 @@ c1 <- fc1
       startAt.innerNodeTraverser.strongComponents(_ => ())
     }
 
-    def `path builder` {
+    def `path builder`: Unit = {
       val builder = g.newPathBuilder(n(1))
       builder += n(3) += n(4)
       builder.result               .toString should be ("Path(1, 1~>3 %5.0, 3, 3~4 %1.0, 4)")

--- a/core/src/test/scala/scalax/collection/TConnectivity.scala
+++ b/core/src/test/scala/scalax/collection/TConnectivity.scala
@@ -36,28 +36,25 @@ final class TConnectivity[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphL
     import Data.elementsOfDi_1
     val g = factory(elementsOfDi_1: _*)
 
-    def `there exists no pair of mutually reachable nodes` {
+    def `there exists no pair of mutually reachable nodes`: Unit =
       given(g) {
         _.nodes.toList.combinations(2) foreach {
           case List(a, b) => List(a pathTo b, b pathTo a) should contain(None)
         }
       }
-    }
 
-    def `evaluating strong components from any node yields single-node components` {
+    def `evaluating strong components from any node yields single-node components`: Unit =
       given(g) {
         _.nodes foreach { n =>
           val components = n.innerNodeTraverser.strongComponents
           components foreach (_.nodes should have size (1))
         }
       }
-    }
 
-    def `evaluating all strong components yields a component for every node` {
+    def `evaluating all strong components yields a component for every node`: Unit =
       given(g) { g =>
         g.strongComponentTraverser().size should be(g.order)
       }
-    }
   }
 
   object `Having two strong components` {
@@ -69,14 +66,13 @@ final class TConnectivity[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphL
     assert(sccExpected.size == 2)
     assert(sccExpected(0).intersect(sccExpected(1)) == factory.empty)
 
-    def `each is detected as such` {
+    def `each is detected as such`: Unit =
       sccExpected foreach (g =>
         given(g) {
           _.strongComponentTraverser() should have size (1)
         })
-    }
 
-    def `connected by a diEdge yields a graph with the very same two strong components` {
+    def `connected by a diEdge yields a graph with the very same two strong components`: Unit = {
       val r     = new Random
       val union = (factory.empty[Symbol, DiEdge] /: sccExpected)((r, g) => g union r)
       val connectors = {
@@ -108,9 +104,8 @@ final class TConnectivity[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphL
 
   object `Having two weak components` {
 
-    def `weak components are detected, fix #57` {
+    def `weak components are detected, fix #57`: Unit =
       given(factory(11 ~> 12, 13 ~> 14)) { _.componentTraverser() should have size 2 }
-    }
   }
 
   object `Having a bigger graph` {
@@ -124,19 +119,17 @@ final class TConnectivity[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphL
     }
     lazy val strongComponents = g.strongComponentTraverser().toVector
 
-    def `no stack overflow occurs` {
+    def `no stack overflow occurs`: Unit =
       given(g) { _ =>
         strongComponents
       }
-    }
 
-    def `strong components are complete` {
+    def `strong components are complete`: Unit =
       given(g) { _ =>
         (Set.empty[g.NodeT] /: strongComponents)((cum, sc) => cum ++ sc.nodes) should be(g.nodes)
       }
-    }
 
-    def `strong components are proper` {
+    def `strong components are proper`: Unit =
       given(g) { _ =>
         val maxProbes = 10
         val arbitraryNodes: Vector[Set[g.NodeT]] = strongComponents map { sc =>
@@ -178,6 +171,5 @@ final class TConnectivity[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphL
           }
         }
       }
-    }
   }
 }

--- a/core/src/test/scala/scalax/collection/TCycle.scala
+++ b/core/src/test/scala/scalax/collection/TCycle.scala
@@ -67,7 +67,7 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
       )
     }
 
-    def `the cycle returned by 'findCycle' contains the expected nodes` {
+    def `the cycle returned by 'findCycle' contains the expected nodes`: Unit = {
       given(acyclic_1) { g =>
         (g get 1 findCycle) should be(None)
       }
@@ -100,7 +100,7 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
         var i, j = 0
         factory.fill(5) { i += 1; j = i + 1; i ~> j }
       }
-      def fromEachNode[N, E[X] <: EdgeLikeIn[X]](noCycles: Set[N], cycle: Graph[N, E]#Cycle) {
+      def fromEachNode[N, E[X] <: EdgeLikeIn[X]](noCycles: Set[N], cycle: Graph[N, E]#Cycle): Unit =
         given(cycle.nodes.head.containingGraph.asInstanceOf[CC[N, E]]) {
           _.nodes foreach { n =>
             val found = n.findCycle
@@ -108,7 +108,6 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
             else (found.get sameAs cycle) should be(true)
           }
         }
-      }
       given(g + 4 ~> 2) { g =>
         val cycle = g get 3 findCycle
 
@@ -123,7 +122,7 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
       }
     }
 
-    def `the cycle returned by 'findCycleContaining' contains the expected nodes` {
+    def `the cycle returned by 'findCycleContaining' contains the expected nodes`: Unit = {
       given(acyclic_1) { g =>
         g.findCycleContaining(g get 1) should be(None)
       }
@@ -156,7 +155,7 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
       }
     }
 
-    def `the cycle returned by 'partOfCycle' combined with fluent properties contains the expected nodes` {
+    def `the cycle returned by 'partOfCycle' combined with fluent properties contains the expected nodes`: Unit =
       given(cyclic_22) { g =>
         def n(outer: Int) = g get outer
 
@@ -166,9 +165,8 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
         n(4).withSubgraph(nodes = _ != 3) partOfCycle () should haveOneNodeSequenceOf(Seq(4, 5, 6, 1, 4))
         n(2).withSubgraph(nodes = _ != 3) partOfCycle () should be(None)
       }
-    }
 
-    def `the cycle returned by 'findCycle' contains the expected edges` {
+    def `the cycle returned by 'findCycle' contains the expected edges`: Unit = {
       given(acyclic_1) { _.findCycle should be(None) }
       given(cyclic_1) { _.findCycle.get.edges should contain(cyclicEdge_1) }
       given(acyclic_2) { _.findCycle should be(None) }
@@ -176,7 +174,7 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
       given(cyclic_22) { _.findCycle.get.edges should contain(cyclicEdge_22) }
     }
 
-    def `the cycle returned by 'findCycleContaining' contains the expected edges` {
+    def `the cycle returned by 'findCycleContaining' contains the expected edges`: Unit = {
       given(cyclic_1) { g =>
         g.findCycleContaining(g get 2).get.edges should contain(cyclicEdge_1)
       }
@@ -188,7 +186,7 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
       }
     }
 
-    def `'isCyclic' returns the expected result` {
+    def `'isCyclic' returns the expected result`: Unit = {
       given(acyclic_1) { _ should be('isAcyclic) }
       given(cyclic_1) { _ should be('isCyclic) }
       given(acyclic_2) { _ should be('isAcyclic) }
@@ -196,7 +194,7 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
       given(cyclic_22) { _ should be('isCyclic) }
     }
 
-    def `they are cyclic if they contain a self loop #76` {
+    def `they are cyclic if they contain a self loop #76`: Unit = {
       val loop = 1 ~> 1
       given(acyclic_1 + loop) { _ should be('isCyclic) }
       given(factory(loop)) { g =>
@@ -215,7 +213,7 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
     private val unDiCyclic_21 = unDiAcyclic_2 + 3 ~ 5
     private val unDiCyclic_22 = unDiAcyclic_2 ++ List(3 ~ 6, 6 ~ 7, 7 ~ 4)
 
-    def `the cycle returned by 'findCycle' contains the expected nodes` {
+    def `the cycle returned by 'findCycle' contains the expected nodes`: Unit = {
       given(unDiAcyclic_1) { g =>
         (g get 1 findCycle) should be(None)
       }
@@ -233,7 +231,7 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
       }
     }
 
-    def `the cycle returned by 'findCycleContaining' contains the expected nodes` {
+    def `the cycle returned by 'findCycleContaining' contains the expected nodes`: Unit = {
       given(unDiAcyclic_1) { g =>
         g.findCycleContaining(g get 1) should be(None)
       }
@@ -257,7 +255,7 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
       }
     }
 
-    def `the cycle returned by 'partOfCycle' combined with fluent properties contains the expected nodes` {
+    def `the cycle returned by 'partOfCycle' combined with fluent properties contains the expected nodes`: Unit = {
       given(unDiCyclic_21) { g =>
         (g get 1).withSubgraph(nodes = _ != 2) partOfCycle () should be(None)
       }
@@ -273,30 +271,28 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
     private val (e1, e2) = (WkUnDiEdge(1, 2)(0), WkUnDiEdge(1, 2)(1))
     private val g        = factory(e1, e2)
 
-    def `the cycle returned by 'findCycle' contains the expected edges` {
+    def `the cycle returned by 'findCycle' contains the expected edges`: Unit =
       given(g) { g =>
         val c = (g get 1).findCycle
         c should be('isDefined)
         c.get.edges should (be(List(e1, e2)) or
           be(List(e2, e1)))
       }
-    }
 
-    def `the cycle returned by 'findCycleContaining' contains the expected edges` {
+    def `the cycle returned by 'findCycleContaining' contains the expected edges`: Unit =
       given(g) { g =>
         val c = g.findCycleContaining(g get 1)
         c should be('isDefined)
         c.get.edges should (be(List(e1, e2)) or
           be(List(e2, e1)))
       }
-    }
   }
 
   object `given some mixed graphs` extends CycleMatcher[Int, UnDiEdge] {
 
     private val mixed = factory(Data.elementsOfUnDi_1: _*)
 
-    def `'findCycle' finds a cycle following any route` {
+    def `'findCycle' finds a cycle following any route`: Unit = {
       given(
         factory(
           1 ~> 3,
@@ -319,7 +315,7 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
       }
     }
 
-    def `the cycle returned by 'findCycleContaining' contains the expected nodes` {
+    def `the cycle returned by 'findCycleContaining' contains the expected nodes`: Unit =
       given(mixed) { g =>
         def n(outer: Int) = g get outer
 
@@ -342,9 +338,8 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
           Seq(4, 5, 1, 2, 3, 4),
           Seq(4, 5, 1, 3, 4))
       }
-    }
 
-    def `the cycle returned by 'partOfCycle' combined with fluent properties contains the expected nodes` {
+    def `the cycle returned by 'partOfCycle' combined with fluent properties contains the expected nodes`: Unit =
       given(mixed) { g =>
         def n(outer: Int) = g get outer
 
@@ -359,12 +354,11 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
 
         n(1).withSubgraph(nodes = _ != 5).partOfCycle should haveOneNodeSequenceOf(Seq(1, 3, 2, 1))
       }
-    }
 
     private val g          = factory(1 ~ 2, 1 ~> 2, 2 ~ 3)
     private val cycleEdges = List(1 ~> 2, 1 ~ 2)
 
-    def `the cycle returned by 'findCycle' contains the expected edges` {
+    def `the cycle returned by 'findCycle' contains the expected edges`: Unit =
       given(g) { g =>
         g.graphSize should be(3)
         g.nodes foreach { n =>
@@ -373,9 +367,8 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
           c.get.edges should (be(cycleEdges) or be(cycleEdges.reverse))
         }
       }
-    }
 
-    def `the cycle returned by 'findCycleContaining' contains the expected edges` {
+    def `the cycle returned by 'findCycleContaining' contains the expected edges`: Unit =
       given(g) { g =>
         g.nodes.filterNot(_.toOuter == 3) foreach { n =>
           val c = g.findCycleContaining(g get n)
@@ -384,6 +377,5 @@ class TCycle[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC
             be(cycleEdges.reverse))
         }
       }
-    }
   }
 }

--- a/core/src/test/scala/scalax/collection/TDegree.scala
+++ b/core/src/test/scala/scalax/collection/TDegree.scala
@@ -47,7 +47,7 @@ class TDegree[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, C
   }
 
   object `Degrees are calculated properly` {
-    def `for nodes` {
+    def `for nodes`: Unit = {
       {
         import UnDi_1._
         given(g) { _ =>
@@ -67,7 +67,7 @@ class TDegree[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, C
         }
       }
     }
-    def `for total graph` {
+    def `for total graph`: Unit = {
       emptyG.totalDegree should be(0);
       {
         import UnDi_1._
@@ -81,7 +81,7 @@ class TDegree[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, C
   }
 
   object `Degree statistics are calculated properly for` {
-    def `minimum degree` {
+    def `minimum degree`: Unit = {
       emptyG.minDegree should be(0);
       {
         import UnDi_1._
@@ -92,7 +92,7 @@ class TDegree[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, C
         given(g) { _.minDegree should be(degrees min) }
       }
     }
-    def `maximum degree` {
+    def `maximum degree`: Unit = {
       emptyG.maxDegree should be(0);
       {
         import UnDi_1._
@@ -103,7 +103,7 @@ class TDegree[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, C
         given(g) { _.maxDegree should be(degrees max) }
       }
     }
-    def `sequence of degrees` {
+    def `sequence of degrees`: Unit = {
       emptyG.degreeSeq should be(Seq.empty);
       {
         import UnDi_1._
@@ -114,7 +114,7 @@ class TDegree[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, C
         given(g) { _.degreeSeq should be(expectedDegreeSeq) }
       }
     }
-    def `set of degrees` {
+    def `set of degrees`: Unit = {
       emptyG.degreeSet should be(Set.empty);
       {
         import UnDi_1._
@@ -125,7 +125,7 @@ class TDegree[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, C
         given(g) { _.degreeSet should be(expectedDegreeSet) }
       }
     }
-    def `sequence of nodes sorted by degree` {
+    def `sequence of nodes sorted by degree`: Unit = {
       emptyG.degreeNodeSeq should be(Seq.empty);
       {
         import UnDi_1._
@@ -152,7 +152,7 @@ class TDegree[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, C
         given(g) { _.degreeNodeSeq should be(expectedDegreeNodeSeq) }
       }
     }
-    def `map of nodes by degree` {
+    def `map of nodes by degree`: Unit = {
       emptyG.degreeNodesMap should be(Map.empty);
       {
         import UnDi_1._
@@ -168,7 +168,7 @@ class TDegree[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, C
         }
       }
     }
-    def `map of degree by node` {
+    def `map of degree by node`: Unit = {
       emptyG.degreeCount should be(Map.empty);
       {
         import UnDi_1._

--- a/core/src/test/scala/scalax/collection/TEdge.scala
+++ b/core/src/test/scala/scalax/collection/TEdge.scala
@@ -45,7 +45,7 @@ class TEdgeTest extends RefSpec with Matchers {
 
     def outerEdges(implicit kind: CollectionKind = Bag): List[E[_]]
 
-    def `are treated as a bag by default` {
+    def `are treated as a bag by default`: Unit = {
       val edges = outerEdges()
       edges(1) should be(edges(2))
       val g = Graph(edges: _*)
@@ -53,7 +53,7 @@ class TEdgeTest extends RefSpec with Matchers {
       ordered(g.edges) should be(false)
     }
 
-    def `may be defined to be sorted.` {
+    def `may be defined to be sorted.` : Unit = {
       val edges = outerEdges(Sequence)
       edges(1) should not equal (edges(2))
       val g = Graph(edges: _*)
@@ -86,7 +86,7 @@ class TEdgeTest extends RefSpec with Matchers {
 
   object `Custom edge tests` {
 
-    def `LkDiEdge ` {
+    def `LkDiEdge ` : Unit = {
       val outer = LkDiEdge(ham, gig)(Flight(flightNo))
       val g     = Graph(outer)
       val e     = g.edges.head
@@ -104,15 +104,15 @@ class TEdgeTest extends RefSpec with Matchers {
       e.## should not be (neFlight.##)
     }
 
-    def `LkDiEdgeShortcut ` {
+    def `LkDiEdgeShortcut ` : Unit = {
       val outer = LkDiEdge(ham, gig)(Flight(flightNo))
       (ham ~+#> gig)(Flight(flightNo)) should be(outer)
       (ham ~+#> gig)(Flight(flightNo, 11 o 20)) should be(outer)
     }
 
-    def `matching weighted edges` {
+    def `matching weighted edges`: Unit = {
       val (n1, n2, w) = (1, 2, 5)
-      def check(_n1: Int, _n2: Int, _w: Double) {
+      def check(_n1: Int, _n2: Int, _w: Double): Unit = {
         _n1 should be(n1)
         _n2 should be(n2)
         _w should be(w)
@@ -129,12 +129,12 @@ class TEdgeTest extends RefSpec with Matchers {
       wkDi match { case s :~> t % w => check(s, t, w) }
     }
 
-    def `matching labeled edges` {
+    def `matching labeled edges`: Unit = {
       object StringLabel extends LEdgeImplicits[String]
       import StringLabel._
 
       val (n1, n2, label) = (1, 2, "A")
-      def check(_n1: Int, _n2: Int, _label: String) {
+      def check(_n1: Int, _n2: Int, _label: String): Unit = {
         _n1 should be(n1)
         _n2 should be(n2)
         _label should be(label)
@@ -151,12 +151,12 @@ class TEdgeTest extends RefSpec with Matchers {
       lkDi match { case s :~> t + l => check(s, t, l) }
     }
 
-    def `matching weighted labeled edges` {
+    def `matching weighted labeled edges`: Unit = {
       object StringLabel extends LEdgeImplicits[String]
       import StringLabel._
 
       val (n1, n2, label, weight) = (1, 2, "A", 4d)
-      def check(_n1: Int, _n2: Int, _weight: Double, _label: String) {
+      def check(_n1: Int, _n2: Int, _weight: Double, _label: String): Unit = {
         _n1 should be(n1)
         _n2 should be(n2)
         _weight should be(weight)
@@ -174,7 +174,7 @@ class TEdgeTest extends RefSpec with Matchers {
       wlkDi match { case s :~> t %+ (w, l) => check(s, t, w, l) }
     }
 
-    def `findOutgoingTo LkDiEdge` {
+    def `findOutgoingTo LkDiEdge`: Unit = {
       import edge.LkDiEdge
       val le  = LkDiEdge(1, 1)(1)
       val lg  = Graph(le)
@@ -182,7 +182,7 @@ class TEdgeTest extends RefSpec with Matchers {
       (ln1 findOutgoingTo ln1) should be(Some(le))
     }
 
-    def `LkHyperEdge equality` {
+    def `LkHyperEdge equality`: Unit = {
       val e1 = LkDiHyperEdge(1, 1)("a")
       val e2 = LkHyperEdge(1, 1)("b")
       val g  = Graph[Int, LHyperEdge](e1, e2)
@@ -191,7 +191,7 @@ class TEdgeTest extends RefSpec with Matchers {
       g find e2 should be('defined)
     }
 
-    def `LkDiHyperEdge equality` {
+    def `LkDiHyperEdge equality`: Unit = {
       val e  = LkDiHyperEdge(1, 2, 3)("a")
       val g  = Graph[Int, LHyperEdge](e)
       val eo = g.edges.head.toOuter

--- a/core/src/test/scala/scalax/collection/TEdit.scala
+++ b/core/src/test/scala/scalax/collection/TEdit.scala
@@ -50,11 +50,11 @@ class TEditRootTest
 @RunWith(classOf[JUnitRunner])
 class TEditImmutable extends RefSpec with Matchers {
   object `graphs ` {
-    def `are immutable by default` {
+    def `are immutable by default`: Unit = {
       val g = Graph[Nothing, Nothing]()
       g.isInstanceOf[immutable.Graph[Nothing, Nothing]] should be(true)
     }
-    def `yield another graph when mapped` {
+    def `yield another graph when mapped`: Unit = {
       val g                                 = immutable.Graph(1 ~ 2)
       val m: immutable.Graph[Int, UnDiEdge] = g map Helper.icrementNode
       m.edges.head should be(UnDiEdge(2, 3))
@@ -65,14 +65,14 @@ class TEditImmutable extends RefSpec with Matchers {
 @RunWith(classOf[JUnitRunner])
 class TEditMutable extends RefSpec with Matchers {
   object `mutable graphs` {
-    def `serve += properly` {
+    def `serve += properly`: Unit = {
       val g = mutable.Graph[Int, Nothing](1, 3)
       g += 2
       g should have size (3)
       for (i <- 1 to 3)
         g.contains(i) should be(true) //g should contain (i)
     }
-    def `serve -= properly` {
+    def `serve -= properly`: Unit = {
       val g = mutable.Graph(1, 2, 2 ~ 3, 4)
       g remove 1 should be(true)
       g should be(mutable.Graph(2 ~ 3, 4))
@@ -83,12 +83,12 @@ class TEditMutable extends RefSpec with Matchers {
       g.clear
       g should be('empty)
     }
-    def `serve -= properly (2)` {
+    def `serve -= properly (2)` : Unit = {
       val g = mutable.Graph(1 ~ 2, 2 ~ 3)
       (g -= 2) should be(mutable.Graph[Int, UnDiEdge](1, 3))
       g.graphSize should be(0)
     }
-    def `serve 'directed' properly` {
+    def `serve 'directed' properly`: Unit = {
       val (di, unDi)                        = (1 ~> 2, 2 ~ 3)
       val g                                 = mutable.Graph(unDi)
       def directed(expected: Boolean): Unit = g.isDirected should be(expected)
@@ -99,7 +99,7 @@ class TEditMutable extends RefSpec with Matchers {
       g += unDi; directed(false)
       g.clear; directed(true)
     }
-    def `serve 'diSuccessors' when directed` {
+    def `serve 'diSuccessors' when directed`: Unit = {
       val (one, two, oneOne, oneTwo) = (1, 2, 1 ~> 1, 1 ~> 2)
       val g                          = mutable.Graph(oneOne, oneTwo, one ~> 3, one ~> 4)
       val (n1, n2)                   = (g get one, g get two)
@@ -122,7 +122,7 @@ class TEditMutable extends RefSpec with Matchers {
       (n1 diSuccessors) should be(Set(two, 3))
       (n1 ~>? n1) should be(Some(e11))
     }
-    def `'diSuccessors' when directed hypergraph` {
+    def `'diSuccessors' when directed hypergraph`: Unit = {
       val (one, two, three, oneOneTwo, oneTwoThree) = (1, 2, 3, 1 ~> 1 ~> 2, 1 ~> 2 ~> 3)
       val g                                         = mutable.Graph(oneOneTwo, oneTwoThree)
       val (n1, n2)                                  = (g get one, g get two)
@@ -144,7 +144,7 @@ class TEditMutable extends RefSpec with Matchers {
       (n1 diSuccessors) should be(Set(2))
       (n1 ~>? n1) should be(Some(oneOneTwo))
     }
-    def `serve +~` {
+    def `serve +~` : Unit = {
       val g                    = mutable.Graph(2 ~ 3)
       def n(i: Int)            = g get i
       implicit val unDiFactory = UnDiEdge
@@ -160,14 +160,14 @@ class TEditMutable extends RefSpec with Matchers {
       (n(3) +~ n(2))(DiEdge)
       g should have('order (3), 'graphSize (5))
     }
-    def `serve +~ for hyperedeges` {
+    def `serve +~ for hyperedeges`: Unit = {
       implicit val factory = HyperEdge
       val h                = mutable.Graph(1 ~ 1 ~ 2)
       h should have('order (2), 'graphSize (1))
       h +~= (0, 1, 2, 3)
       h should have('order (4), 'graphSize (2))
     }
-    def `serve +~%= for weighted edeges` {
+    def `serve +~%= for weighted edeges`: Unit = {
       val g          = mutable.Graph(2 ~ 3)
       implicit val f = edge.WUnDiEdge
       g.addWEdge(3, 4)(2)
@@ -176,7 +176,7 @@ class TEditMutable extends RefSpec with Matchers {
       g should have('order (3), 'graphSize (3), 'totalWeight (6))
       // (g +~%= (0,1,2,3))(3)(edge.WHyperEdge) // must not compile
     }
-    def `serve +~%= weighted hyperedeges` {
+    def `serve +~%= weighted hyperedeges`: Unit = {
       implicit val factory = edge.WHyperEdge
       val h                = mutable.Graph(1 ~ 1 ~ 2)
       h should have('order (2), 'graphSize (1))
@@ -185,7 +185,7 @@ class TEditMutable extends RefSpec with Matchers {
       (h +~%= (0, 1, 2, 3))(3)
       h should have('order (6), 'graphSize (3), 'totalWeight (6))
     }
-    def `fulfill labeled edege equality` {
+    def `fulfill labeled edege equality`: Unit = {
       import edge.Implicits._
       import edge.LDiEdge
 
@@ -215,7 +215,7 @@ class TEditMutable extends RefSpec with Matchers {
       added.directed should be(true)
       added.count(_ > 0) should be(List(1, 0, 1).count(_ > 0))
     }
-    def `fulfill labeled directed hyperedege equality` {
+    def `fulfill labeled directed hyperedege equality`: Unit = {
       import edge.Implicits._
       import edge.LHyperEdge
 
@@ -241,14 +241,14 @@ class TEditMutable extends RefSpec with Matchers {
        */
       (innerLabels: Iterable[Any]) forall (outerLabels contains _) should be(true)
     }
-    def `serve ++=` {
+    def `serve ++=` : Unit = {
       val (gBefore, gAfter) = (mutable.Graph(1, 2 ~ 3), mutable.Graph(0, 1 ~ 2, 2 ~ 3))
       (gBefore ++= List[Param[Int, UnDiEdge]](1 ~ 2, 2 ~ 3, 0)) should equal(gAfter)
       (gBefore ++= mutable.Graph(0, 1 ~ 2)) should equal(gAfter)
       (gBefore ++= mutable.Graph[Int, UnDiEdge](0)
         ++= mutable.Graph(1 ~ 2)) should equal(gAfter)
     }
-    def `are upsertable` {
+    def `are upsertable`: Unit = {
       import edge.LDiEdge
       val (label, modLabel) = ("A", "B")
       val g                 = mutable.Graph(LDiEdge(1, 2)(label), LDiEdge(2, 3)(label))
@@ -261,7 +261,7 @@ class TEditMutable extends RefSpec with Matchers {
       g should have('graphSize (2))
       g.edges foreach { _.label should be(modLabel) }
     }
-    def `yield another graph when mapped` {
+    def `yield another graph when mapped`: Unit = {
       import mutable.Graph
       val g                       = Graph(1 ~ 2)
       val m: Graph[Int, UnDiEdge] = g map Helper.icrementNode
@@ -283,13 +283,13 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
   val gString_A = factory[String, Nothing]("A")
 
   object `graph editing includes` {
-    def `empty ` {
+    def `empty ` : Unit = {
       val eg = factory.empty[Nothing, Nothing]
       eg should be('isEmpty)
       eg should have size (0)
       eg should equal(eg.empty)
     }
-    def `apply ` {
+    def `apply ` : Unit = {
       gInt_1_3 should not be ('isEmpty)
       gInt_1_3 should have size (2)
       gInt_1_3(0) should be(false)
@@ -309,13 +309,13 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       h.edges should have size (2)
       h should have size (5)
     }
-    def `nodes of ADT fixes #40` {
+    def `nodes of ADT fixes #40`: Unit = {
       trait Node
       case class N1() extends Node
       case class N2() extends Node
       factory(N1() ~> N2(), N1() ~> N1())
     }
-    def `isDirected ` {
+    def `isDirected ` : Unit = {
       def directed(g: CC[Int, UnDiEdge], expected: Boolean): Unit = g.isDirected should be(expected)
       val wDi                                                     = edge.WDiEdge(1, 2)(0)
 
@@ -325,14 +325,14 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       directed(factory(wDi), true)
       directed(factory(0 ~> 1, wDi), true)
     }
-    def `isHyper ` {
+    def `isHyper ` : Unit = {
       def hyper(g: CC[Int, HyperEdge], expected: Boolean): Unit = g.isHyper should be(expected)
 
       factory(1 ~ 2).isHyper should be(false)
       hyper(factory(1 ~> 2, 1 ~ 2 ~ 3), true)
       hyper(factory(1 ~> 2), false)
     }
-    def `isMulti ` {
+    def `isMulti ` : Unit = {
       import edge.WkDiEdge
       def multi(g: CC[Int, UnDiEdge], expected: Boolean): Unit = g.isMulti should be(expected)
       val (wDi_1, wDi_2)                                       = (WkDiEdge(1, 2)(0), WkDiEdge(1, 2)(1))
@@ -341,7 +341,7 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       multi(factory(1 ~ 2, 1 ~> 2), false)
       multi(factory(wDi_1, wDi_2), true)
     }
-    def `from ` {
+    def `from ` : Unit = {
       val (n_start, n_end) = (11, 20)
       val nodes            = List.range(n_start, n_end)
       val edges            = List[DiEdge[Int]](14 ~> 16, 16 ~> 18, 18 ~> 20, 20 ~> 22)
@@ -349,18 +349,18 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       g.nodes.size should be(nodes.size + 2)
       g.edges.size should be(edges.size)
     }
-    def `contains ` {
+    def `contains ` : Unit = {
       seq_1_3 foreach { i =>
         gInt_1_3.contains(i) should be(true) //gInt_1_3 should contain (i)
       }
       gInt_1_3.head.isInstanceOf[InnerNodeParam[Int]] should be(true)
     }
-    def `toString ` {
+    def `toString ` : Unit = {
       val nodePrefix = OuterNode.stringPrefix
       gInt_1_3.toString should fullyMatch regex ("""Graph\(""" + nodePrefix + """[13], """ + nodePrefix + """[13]\)""")
       gString_A.toString should fullyMatch regex ("""Graph\(""" + nodePrefix + """["A"]\)""")
     }
-    def `from inner ` {
+    def `from inner ` : Unit = {
       val gn = factory[Int, UnDiEdge](2, 3)
       factory(gn.nodes: _*) should equal(gn)
       factory.from[Int, Nothing](gn.nodes, Nil) should equal(gn)
@@ -370,14 +370,14 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       factory(g.edges: _*) should equal(g)
       factory.from[Int, UnDiEdge](edges = g.edges) should equal(g)
     }
-    def `+ Int` {
+    def `+ Int`: Unit = {
       val g = factory(1, 2 ~ 3)
       g + 1 should be(g)
       g + 0 should be(Graph(0, 1, 2, 3, 2 ~ 3))
       g + 0 ~ 1 should be(Graph(0, 1, 2, 3, 0 ~ 1, 2 ~ 3))
       //g + "A" !!! // error: type mismatch
     }
-    def `+ String ` {
+    def `+ String ` : Unit = {
       val g = gString_A + "B"
       g should have size (2)
       g.contains("A") should be(true) //g should contain ("A")
@@ -389,7 +389,7 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       h.edges should have size (1)
       h should have size (3)
     }
-    def `++ ` {
+    def `++ ` : Unit = {
       val g = gString_A + "B" + "C"
       g should have size (3)
       g.contains("A") should be(true) //g should contain ("A")
@@ -401,7 +401,7 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       gBefore ++ factory(0, 1 ~ 2) should equal(gAfter)
       gBefore ++ factory[Int, UnDiEdge](0) ++ factory(1 ~ 2) should equal(gAfter)
     }
-    def `- ` {
+    def `- ` : Unit = {
       var g = gString_A - "B"
       g should have size (1)
 
@@ -416,24 +416,24 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       h -? 2 should be(h)
       h - 2 should be(factory[Int, UnDiEdge](1, 3))
     }
-    def `-- ` {
+    def `-- ` : Unit = {
       val g = factory(1, 2 ~ 3, 3 ~ 4)
       g -- List[Param[Int, UnDiEdge]](2, 3 ~ 3) should be(factory(1, 3 ~ 4))
       g -- List[Param[Int, UnDiEdge]](2, 3 ~ 4) should be(factory[Int, UnDiEdge](1, 3, 4))
       g --! List[Param[Int, UnDiEdge]](1, 3 ~ 4) should be(factory(2 ~ 3))
     }
-    def `CanBuildFrom UnDi` {
+    def `CanBuildFrom UnDi`: Unit = {
       val g                       = factory(0, 1 ~ 2)
       val m: Graph[Int, UnDiEdge] = g map Helper.icrementNode
       m find 1 should be('defined)
       m.edges.head should be(UnDiEdge(2, 3))
     }
-    def `CanBuildFrom Di` {
+    def `CanBuildFrom Di`: Unit = {
       val g                          = factory(1 ~> 2)
       val m: Graph[String, UnDiEdge] = g map Helper.nodeToString
       m.edges.head should be("1" ~ "2")
     }
-    def `NodeSet ` {
+    def `NodeSet ` : Unit = {
       val o = Array.range(0, 4)
       val g = factory(o(1) ~ o(2), o(2) ~ o(3))
       val n = o map (g.nodes find _ getOrElse g.nodes.head)
@@ -450,7 +450,7 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       restored should contain(n(3))
       restored.find(_ == n(1)).get.edges should have size (1)
     }
-    def `Eq ` {
+    def `Eq ` : Unit = {
       factory[Int, Nothing]() shouldEqual factory[Int, Nothing]()
       gInt_1_3 shouldEqual factory(seq_1_3.toOuterNodes[DiEdge]: _*)
       gString_A shouldEqual factory[String, Nothing]("A")
@@ -461,7 +461,7 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
 
       gInt_1_3 should be(factory[Int, DiEdge](1) + 3)
     }
-    def `EdgeAssoc ` {
+    def `EdgeAssoc ` : Unit = {
       val e = 1 ~ 2
       e.isInstanceOf[UnDiEdge[Int]] should be(true)
       val x = factory(3 ~ 4).nodes
@@ -490,22 +490,22 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       dhe._n(3) should be("D")
     }
     object `diSuccessors ` {
-      def `for UnDi` {
+      def `for UnDi`: Unit = {
         val g = factory(1 ~ 1, 1 ~ 2, 1 ~ 3, 1 ~ 4)
         (g get 1 diSuccessors) should be(Set(2, 3, 4))
         (g get 2 diSuccessors) should be(Set(1))
       }
-      def `for Di` {
+      def `for Di`: Unit = {
         val g = factory(1 ~> 1, 1 ~> 2, 1 ~> 3, 1 ~> 4)
         (g get 1 diSuccessors) should be(Set(2, 3, 4))
         (g get 2 diSuccessors) should be(Set.empty)
       }
-      def `for mixed` {
+      def `for mixed`: Unit = {
         val g = factory(1 ~> 1, 2 ~> 3, 4 ~ 3)
         (g get 2 diSuccessors) should be(Set(3))
         (g get 3 diSuccessors) should be(Set(4))
       }
-      def `for DiHyper` {
+      def `for DiHyper`: Unit = {
         val h = factory(1 ~> 1 ~> 5, 1 ~> 2 ~> 5, 1 ~> 3 ~> 5, 1 ~> 4 ~> 9)
         (h get 1 diSuccessors) should be(Set(2, 3, 4, 5, 9))
         (h get 2 diSuccessors) should be(Set.empty)
@@ -513,22 +513,22 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       }
     }
     object `diPredecessors ` {
-      def `for UnDi` {
+      def `for UnDi`: Unit = {
         val g = factory(1 ~ 1, 1 ~ 2, 1 ~ 3, 1 ~ 4)
         (g get 1 diPredecessors) should be(Set(2, 3, 4))
         (g get 2 diPredecessors) should be(Set(1))
       }
-      def `for Di` {
+      def `for Di`: Unit = {
         val g = factory(1 ~> 1, 1 ~> 2, 1 ~> 3, 1 ~> 4)
         (g get 1 diPredecessors) should be(Set.empty)
         (g get 2 diPredecessors) should be(Set(1))
       }
-      def `for mixed` {
+      def `for mixed`: Unit = {
         val g = factory(1 ~> 2, 2 ~> 3, 4 ~ 3)
         (g get 2 diPredecessors) should be(Set(1))
         (g get 3 diSuccessors) should be(Set(4))
       }
-      def `for DiHyper` {
+      def `for DiHyper`: Unit = {
         val h = factory(1 ~> 1 ~> 5, 1 ~> 2 ~> 5, 1 ~> 3 ~> 5, 1 ~> 4 ~> 9)
         (h get 1 diPredecessors) should be(Set.empty)
         (h get 2 diPredecessors) should be(Set(1))
@@ -536,35 +536,35 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       }
     }
     object `neighbors ` {
-      def `for UnDi` {
+      def `for UnDi`: Unit = {
         val g = factory(1 ~ 1, 1 ~ 2, 1 ~ 3, 1 ~ 4)
         (g get 1 neighbors) should be(Set(2, 3, 4))
         (g get 2 neighbors) should be(Set(1))
       }
-      def `for Di` {
+      def `for Di`: Unit = {
         val g = factory(1 ~> 1, 1 ~> 2, 1 ~> 3, 1 ~> 4)
         (g get 1 neighbors) should be(Set(2, 3, 4))
         (g get 2 neighbors) should be(Set(1))
       }
-      def `for DiHyper` {
+      def `for DiHyper`: Unit = {
         val h = factory(1 ~> 1 ~> 5, 1 ~> 2 ~> 5, 1 ~> 3 ~> 5, 1 ~> 4 ~> 9)
         (h get 1 neighbors) should be(Set(2, 3, 4, 5, 9))
         (h get 2 neighbors) should be(Set(1, 5))
         (h get 5 neighbors) should be(Set(1, 2, 3))
       }
     }
-    def `findOutgoingTo Di` {
+    def `findOutgoingTo Di`: Unit = {
       val g         = factory(1 ~> 1, 1 ~> 2, 2 ~> 1)
       def n(i: Int) = g get i
       (n(1) findOutgoingTo n(2)) should be(Some(1 ~> 2))
       (n(1) findOutgoingTo n(1)) should be(Some(1 ~> 1))
     }
-    def `degree ` {
+    def `degree ` : Unit = {
       val g = factory(1 ~ 1, 1 ~ 2, 1 ~ 3, 1 ~ 4)
       (g get 1 degree) should be(5)
       (g get 2 degree) should be(1)
     }
-    def `incoming ` {
+    def `incoming ` : Unit = {
       val uEdges = Seq[UnDiEdge[Int]](1 ~ 1, 1 ~ 2, 1 ~ 3, 1 ~ 4) // bug if no type param given
       val g      = factory(uEdges(0), uEdges(1), uEdges(2), uEdges(3))
       (g get 1 incoming) should be(uEdges.toSet)
@@ -575,12 +575,12 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       (h get 1 incoming) should be(Set(dEdges(0)))
       (h get 2 incoming) should be(Set(dEdges(1)))
     }
-    def `edgeAdjacents UnDi` {
+    def `edgeAdjacents UnDi`: Unit = {
       val g = Graph(1 ~ 2, 2 ~ 3, 1 ~> 3, 1 ~ 5, 3 ~ 5, 3 ~ 4, 4 ~> 4, 4 ~> 5)
       ((g get 4 ~> 4) adjacents) should be(Set(3 ~ 4, 4 ~> 5))
       ((g get 1 ~ 2) adjacents) should be(Set(1 ~> 3, 1 ~ 5, 2 ~ 3))
     }
-    def `filter ` {
+    def `filter ` : Unit = {
       val g = factory(2 ~> 3, 3 ~> 1, 5)
       g filter ((n: Int) => n > 1) should be(factory(2 ~> 3, 5))
       g filter ((n: Int) => n < 2) should be(factory[Int, DiEdge](1))
@@ -589,7 +589,7 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
       g filter g.having(edge = _._1 == 2) should be(factory(2 ~> 3))
       g filter g.having(edge = _ contains 2) should be(factory(2 ~> 3))
     }
-    def `match ` {
+    def `match ` : Unit = {
       val di = 1 ~> 2
       (di match { case DiEdge(src, _) => src }) should be(1)
       (di match { case src ~> trg     => src + trg }) should be(3)

--- a/core/src/test/scala/scalax/collection/TEquals.scala
+++ b/core/src/test/scala/scalax/collection/TEquals.scala
@@ -18,7 +18,7 @@ class TEqualsTest extends RefSpec with Matchers {
   def initH                = (iFactory.from(none, oEdgesH), mFactory.from(none, oEdgesH))
 
   object `equals works properly` {
-    def `over immutable and mutable graphs` {
+    def `over immutable and mutable graphs`: Unit = {
       val (iG, mG) = initG
       val (iH, mH) = initH
       val ok       = iG == mG

--- a/core/src/test/scala/scalax/collection/TOp.scala
+++ b/core/src/test/scala/scalax/collection/TOp.scala
@@ -24,17 +24,17 @@ class TOp[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]](
   val g = factory(1 ~ 2, 2 ~ 3, 2 ~ 4, 3 ~ 5, 4 ~ 5)
   val h = factory(3 ~ 4, 3 ~ 5, 4 ~ 6, 5 ~ 6)
 
-  def `union ` {
+  def `union ` : Unit = {
     val expected = factory(1 ~ 2, 2 ~ 3, 2 ~ 4, 3 ~ 5, 4 ~ 5, 3 ~ 4, 4 ~ 6, 5 ~ 6)
     given(g union h) { _ should be(expected) }
     given(g ++ h) { _ should be(expected) }
   }
-  def `difference ` {
+  def `difference ` : Unit = {
     val expected = factory(1 ~ 2)
     given(g diff h) { _ should be(expected) }
     given(g -- h) { _ should be(expected) }
   }
-  def `intersection ` {
+  def `intersection ` : Unit = {
     val expected = factory(3 ~ 5, 4)
     given(g intersect h) { _ should be(expected) }
     given(g & h) { _ should be(expected) }
@@ -49,21 +49,21 @@ class TMutableOp extends RefSpec with Matchers {
   val none                 = Set.empty
   def initG                = (iFactory.from(none, oEdgesG), mFactory.from(none, oEdgesG))
   def initH                = (iFactory.from(none, oEdgesH), mFactory.from(none, oEdgesH))
-  def ` union` {
+  def ` union`: Unit = {
     val (iG, mG) = initG
     val (iH, mH) = initH
     val expected = mFactory(1 ~ 2, 2 ~ 3, 2 ~ 4, 3 ~ 5, 4 ~ 5, 3 ~ 4, 4 ~ 6, 5 ~ 6)
     (mG ++= mH) should be(expected)
     (mG ++= iH) should be(expected)
   }
-  def `difference ` {
+  def `difference ` : Unit = {
     val (iG, mG) = initG
     val (iH, mH) = initH
     val expected = mFactory(1 ~ 2)
     (mG --= mH) should be(expected)
     (mG --= iH) should be(expected)
   }
-  def `intersection ` {
+  def `intersection ` : Unit = {
     val (iG, mG) = initG
     val (iH, mH) = initH
     val expected = mFactory(3 ~ 5, 4)

--- a/core/src/test/scala/scalax/collection/TPathBuilder.scala
+++ b/core/src/test/scala/scalax/collection/TPathBuilder.scala
@@ -18,7 +18,7 @@ trait WalkBehaviors {
 
   import AGraph.UnDi_1._
 
-  def walk(builder: => g.WalkBuilder) {
+  def walk(builder: => g.WalkBuilder): Unit = {
     it should "accept neighbors" in { builder add n(3) should be(true) }
     it should "refuse non-neighbors" in { builder add n(4) should be(false) }
     it should "accept outgoing edge" in { builder add (g get 1 ~ 2) should be(true) }

--- a/core/src/test/scala/scalax/collection/TState.scala
+++ b/core/src/test/scala/scalax/collection/TState.scala
@@ -36,23 +36,20 @@ class TStateTest extends RefSpec with Matchers {
   val nrNodesExpected = g.order
   val aLotOfTimes     = 162 // at least 2 times State.nrOfFlagWordBits
 
-  def dump {
+  def dump: Unit =
     println(State.dump(g))
-  }
 
   object `Single-threaded shared state proves robust` {
-    def `when looping` {
+    def `when looping`: Unit =
       for (i <- 1 to aLotOfTimes)
         countNodes() should be(nrNodesExpected)
-    }
-    def `when looping at visited nodes` {
+    def `when looping at visited nodes`: Unit =
       g.nodes.head.innerNodeTraverser foreach (_ => `when looping`)
-    }
-    def `when called recursively` {
+    def `when called recursively`: Unit = {
       val depth = 5
       countNodes(depth) should be(math.pow(3, depth) * nrNodesExpected)
     }
-    def `when called deep-recursively` {
+    def `when called deep-recursively`: Unit = {
       val recurseAt = g.nodes.head
       def countNodesDeep(recursion: Int): Int = {
         assert(recursion >= 0)
@@ -68,7 +65,7 @@ class TStateTest extends RefSpec with Matchers {
       }
       for (i <- 1 to 2) countNodesDeep(aLotOfTimes)
     }
-    def `when cleared up after lots of unconnected traversals` {
+    def `when cleared up after lots of unconnected traversals`: Unit = {
       val order          = 5000
       val r              = new Random(10 * order)
       def intNodeFactory = r.nextInt
@@ -84,7 +81,7 @@ class TStateTest extends RefSpec with Matchers {
     }
   }
   object `Multi-threaded shared state proves robust` {
-    def `when traversing by futures` {
+    def `when traversing by futures`: Unit = {
       val traversals = Future.sequence(
         for (i <- 1 to aLotOfTimes)
           yield Future { countNodes() }
@@ -97,7 +94,7 @@ class TStateTest extends RefSpec with Matchers {
       // each traversal must yield the same result
       stat should be(Map(nrNodesExpected -> aLotOfTimes))
     }
-    def `when tested under stress fixing #34` {
+    def `when tested under stress fixing #34`: Unit = {
       import Data._
       object g extends TGraph[Int, DiEdge, Graph](Graph(elementsOfDi_1: _*))
       def n(outer: Int) = g.node(outer)

--- a/core/src/test/scala/scalax/collection/TTopologicalSort.scala
+++ b/core/src/test/scala/scalax/collection/TTopologicalSort.scala
@@ -83,16 +83,15 @@ private class TTopologicalSort[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with G
       fail(s"Cycle expected but topological order ${order.toLayered} found")
   }
 
-  def `empty graph` {
+  def `empty graph`: Unit =
     given(factory.empty[Int, DiEdge]) {
       _.topologicalSort.fold(
         Topo.unexpectedCycle,
         _ should be('empty)
       )
     }
-  }
 
-  def `daily activities` {
+  def `daily activities`: Unit = {
 
     object Activities {
       val (coffee, coding, inspiration, shopping, sleeping, supper, gaming) =
@@ -132,7 +131,7 @@ private class TTopologicalSort[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with G
     }
   }
 
-  def `connected graph` {
+  def `connected graph`: Unit = {
     val someOuter @ (n0 :: n1 :: n5 :: Nil) = 0 :: 1 :: 5 :: Nil
     given(factory[Int, DiEdge](n0 ~> n1, 2 ~> 4, 2 ~> n5, n0 ~> 3, n1 ~> 4, 4 ~> 3)) { g =>
       g should not be 'isMulti
@@ -155,7 +154,7 @@ private class TTopologicalSort[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with G
     }
   }
 
-  def `multi graph` {
+  def `multi graph`: Unit =
     given(factory(WkDiEdge(1, 2)(0), WkDiEdge(1, 2)(1))) { g =>
       g.topologicalSort.fold(
         Topo.unexpectedCycle,
@@ -165,9 +164,8 @@ private class TTopologicalSort[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with G
         }
       )
     }
-  }
 
-  def `unconnected graph` {
+  def `unconnected graph`: Unit = {
     val expectedLayer_0 @ (_1 :: _3 :: Nil) = List(1, 3)
     val expectedLayer_1 @ (_2 :: _4 :: Nil) = List(2, 4)
     given(factory(_1 ~> _2, _3 ~> _4)) {
@@ -183,25 +181,23 @@ private class TTopologicalSort[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with G
     }
   }
 
-  def `cyclic graph` {
+  def `cyclic graph`: Unit =
     given(factory(1 ~> 2, 2 ~> 1)) {
       _.topologicalSort.fold(
         identity,
         Topo.unexpectedRight
       )
     }
-  }
 
-  def `cyclic graph #68` {
+  def `cyclic graph #68`: Unit =
     given(factory(0 ~> 7, 4 ~> 7, 7 ~> 3, 3 ~> 4, 0 ~> 5)) {
       _.topologicalSort.fold(
         identity,
         Topo.unexpectedRight
       )
     }
-  }
 
-  def `combining with filtered edges by withSubgraph #104` {
+  def `combining with filtered edges by withSubgraph #104`: Unit =
     given(factory((1 ~+> 3)("a"), (1 ~+> 2)("b"), (2 ~+> 3)("a"))) { g =>
       val n1 = (g get 1)
       n1.topologicalSort() should be('isRight)
@@ -216,5 +212,4 @@ private class TTopologicalSort[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with G
           }
         )
     }
-  }
 }

--- a/core/src/test/scala/scalax/collection/TTraversal.scala
+++ b/core/src/test/scala/scalax/collection/TTraversal.scala
@@ -40,7 +40,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
 
   implicit val config = PropertyCheckConfiguration(minSuccessful = 5, maxDiscardedFactor = 1.0)
 
-  def `find successors in a tiny graph` {
+  def `find successors in a tiny graph`: Unit =
     given(factory(1 ~> 2)) { g =>
       val (n1, n2) = (g get 1, g get 2)
 
@@ -57,9 +57,8 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       successor should be('isDefined)
       successor.get should be(n2)
     }
-  }
 
-  def `find predecessors in a tiny graph` {
+  def `find predecessors in a tiny graph`: Unit =
     given(factory(1 ~> 2)) { g =>
       val (n1, n2) = (g get 1, g get 2)
 
@@ -76,9 +75,8 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       predecessor should be('isDefined)
       predecessor.get should be(n1)
     }
-  }
 
-  def `find connected nodes by predicate in a tiny graph` {
+  def `find connected nodes by predicate in a tiny graph`: Unit =
     given(factory(1 ~> 2)) { g =>
       val (n1, n2) = (g get 1, g get 2)
 
@@ -96,13 +94,12 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       connected should be('isDefined)
       connected.get should be(n1)
     }
-  }
 
   import Data._
   object Di_1   extends TGraph(factory(elementsOfDi_1: _*))
   object UnDi_1 extends TGraph(factory(elementsOfUnDi_1: _*))
 
-  def `find successors in a mid-size graph` {
+  def `find successors in a mid-size graph`: Unit = {
     val g             = Di_1
     def n(outer: Int) = g.node(outer)
     var successor     = null.asInstanceOf[Option[g.g.NodeT]]
@@ -127,7 +124,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     }
   }
 
-  def `find predecessors in a mid-size graph` {
+  def `find predecessors in a mid-size graph`: Unit = {
     val g             = Di_1
     def n(outer: Int) = g.node(outer)
     var predecessor   = null.asInstanceOf[Option[g.g.NodeT]]
@@ -152,7 +149,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     }
   }
 
-  def `find connected nodes by predicate in a mid-size graph` {
+  def `find connected nodes by predicate in a mid-size graph`: Unit = {
     val g             = Di_1
     def n(outer: Int) = g.node(outer)
     var connected     = null.asInstanceOf[Option[g.g.NodeT]]
@@ -174,7 +171,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     }
   }
 
-  def `find path to a successor in a tiny graph` {
+  def `find path to a successor in a tiny graph`: Unit =
     given(factory(1, 2 ~ 3, 3 ~ 4, 5 ~ 6, 6 ~ 1)) { g =>
       val n1 = g get 1
       n1 pathUntil (_ == n1) should be(None)
@@ -193,33 +190,29 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       p5.size should be(expected.size + (expected.size - 1))
       p5.length should be(expected.size - 1)
     }
-  }
 
-  def `find path to a successor` {
+  def `find path to a successor`: Unit =
     given(factory(0 ~ 1, 1 ~ 2)) { g =>
       def n(outer: Int) = g get outer
       for (i <- 0 to 2)
         (n(0) pathTo n(i)).get.length should be(i)
     }
-  }
 
-  def `assert fix_110409 of shortestPathTo` {
+  def `assert fix_110409 of shortestPathTo`: Unit =
     given(factory(0 ~ 1, 1 ~ 2, 2 ~ 3)) { g =>
       def n(outer: Int) = g get outer
       (n(0) shortestPathTo n(0)).get.length should be(0)
       (n(0) shortestPathTo n(3)).get.nodes.toList should be(List(0, 1, 2, 3))
       (n(1) shortestPathTo n(3)).get.nodes.toList should be(List(1, 2, 3))
     }
-  }
 
-  def `assert bug 9 of shortestPathTo is fixed` {
+  def `assert bug 9 of shortestPathTo is fixed`: Unit =
     given(factory(0 ~> 1 % 3, 0 ~> 2 % 4, 1 ~> 3 % 3, 2 ~> 3 % 1)) { g =>
       def n(outer: Int) = g get outer
       (n(0) shortestPathTo n(3)).get.nodes.toList should be(List(0, 2, 3))
     }
-  }
 
-  def `shortestPathTo in WDi_1` {
+  def `shortestPathTo in WDi_1`: Unit =
     given(factory(elementsOfWDi_1: _*)) { g =>
       def n(outer: Int) = g get outer
 
@@ -231,9 +224,8 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       (n(4) shortestPathTo n(5)).get.nodes.toList should be(List(4, 3, 5))
       (n(1) shortestPathTo n(5)).get.nodes.toList should be(List(1, 5))
     }
-  }
 
-  def `shortestPathTo in WDi_1 using Float` {
+  def `shortestPathTo in WDi_1 using Float`: Unit =
     given(factory(elementsOfWDi_1: _*)) { g =>
       def n(outer: Int) = g get outer
 
@@ -248,9 +240,8 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
         2,
         3)
     }
-  }
 
-  def `shortestPathTo in WUnDi_1` {
+  def `shortestPathTo in WUnDi_1`: Unit =
     given(factory(elementsOfWUnDi_1: _*)) { g =>
       def shortestPathNodes(from: Int, to: Int): Stream[g.NodeT] = {
         def n(value: Int): g.NodeT = g get value
@@ -266,17 +257,15 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       shortestPathNodes(5, 4) should contain theSameElementsInOrderAs Array(5, 3, 4)
       shortestPathNodes(3, 1) should contain theSameElementsInOrderAs Array(3, 4, 5, 1)
     }
-  }
 
-  def `shortestPathTo withMaxDepth` {
+  def `shortestPathTo withMaxDepth`: Unit =
     given(factory(elementsOfWUnDi_1: _*)) { g =>
       def n(value: Int): g.NodeT = g get value
 
       n(2).innerNodeTraverser.withMaxDepth(2).shortestPathTo(n(5)).get.nodes.toList should be(List(2, 3, 5))
     }
-  }
 
-  def `shortestPathTo withMaxWeight` {
+  def `shortestPathTo withMaxWeight`: Unit =
     given(factory(elementsOfWUnDi_1: _*)) { g =>
       def n(value: Int): g.NodeT = g get value
 
@@ -284,14 +273,13 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       t.withMaxWeight(3).shortestPathTo(n(5)) shouldBe defined
       t.withMaxWeight(2).shortestPathTo(n(5)) shouldBe empty
     }
-  }
 
   // see diagram WUnDi-2.jpg
   val eUnDi_2 = List[WUnDiEdge[Int]](1 ~ 2 % 4, 2 ~ 3 % -1, 1 ~> 3 % 5, 1 ~ 3 % 4, 1 ~> 2 % 3, 2 ~ 2 % 1)
   // 0        1         2         3        4         5
   val gUnDi_2 = factory.from[Int, WUnDiEdge](Set.empty, eUnDi_2)
 
-  def `shortestPathTo in UnDi_2` {
+  def `shortestPathTo in UnDi_2`: Unit =
     given(gUnDi_2) { g =>
       def n(value: Int) = g get value
 
@@ -311,9 +299,8 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       p3_3.nodes.toList should be(List(3))
       p3_3.edges.toList should be('empty)
     }
-  }
 
-  def `traverser withSubgraph` {
+  def `traverser withSubgraph`: Unit =
     given(gUnDi_2) { g =>
       def n(value: Int) = g get value
 
@@ -329,7 +316,6 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       p1_3_wLT4.nodes.toList should be(List(1, 2, 3))
       p1_3_wLT4.edges.toList should be(List(eUnDi_2(4), eUnDi_2(1)))
     }
-  }
 
   object `traverser withMaxWeight` {
     object WUnDi_1 extends TGraph[Int, WUnDiEdge, G](factory(elementsOfWUnDi_1: _*))
@@ -349,7 +335,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     private def floatWeight(e: g.EdgeT): Float = e.weight.toFloat
   }
 
-  def `traverser with a visitor` {
+  def `traverser with a visitor`: Unit =
     given(gUnDi_2) { g =>
       def n(value: Int) = g get value
 
@@ -367,9 +353,8 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       nodes should be(List(n(2), n(1)))
       edges.toList.sorted(g.Edge.WeightOrdering) should be(List(eUnDi_2(1), eUnDi_2(5), eUnDi_2(0)))
     }
-  }
 
-  def `traverser with an extended visitor` {
+  def `traverser with an extended visitor`: Unit = {
     import UnDi_1.g.ExtendedNodeVisitor
     import UnDi_1.g.Informer.DfsInformer
     def n(outer: Int) = UnDi_1.node(outer)
@@ -396,7 +381,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     }
   }
 
-  def `shortestPathTo in the flight example graph` {
+  def `shortestPathTo in the flight example graph`: Unit = {
     import custom.flight._, Helper._, Flight.ImplicitEdge
     val (jfc, lhr, dme, svx, fra, prg) =
       (Airport("JFC"), Airport("LHR"), Airport("DME"), Airport("SVX"), Airport("FRA"), Airport("PRG"))
@@ -443,7 +428,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     }
   }
 
-  def `traverser withMaxDepth` {
+  def `traverser withMaxDepth`: Unit = {
     import Data._
     object UnDi_1 extends TGraph(factory(elementsOfUnDi_1: _*)) {
       val expectedSumAll           = 15
@@ -472,7 +457,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     }
   }
 
-  def `DownUp traverser` {
+  def `DownUp traverser`: Unit =
     given(Di_1.g) { g =>
       def innerNode(outer: Int) = g get outer
       var stack                 = List.empty[Int]
@@ -487,9 +472,8 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       })
       stack should be('empty)
     }
-  }
 
-  def `DownUp traverser for computing braces` {
+  def `DownUp traverser for computing braces`: Unit = {
     val root = "A"
     given(factory(root ~> "B1", root ~> "B2")) { g =>
       val innerRoot = g get root
@@ -509,7 +493,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     def balance: Int
   }
 
-  def `DownUp traverser for computing sums` {
+  def `DownUp traverser for computing sums`: Unit = {
     case class Node(override val name: String) extends Elem(name) {
       var sum: Int = 0
       def balance  = sum
@@ -548,7 +532,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     }
   }
 
-  def `traverser withDirection` {
+  def `traverser withDirection`: Unit = {
     // https://groups.google.com/forum/?fromgroups=#!topic/scala-internals/9NMPfU4xdhU
     object DDi_1 extends TGraph(factory(elementsOfDi_1: _*)) {
       val expectedSumSuccessorsOf_4   = 12
@@ -590,7 +574,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     }
   }
 
-  def `traverser withOrdering for nodes` {
+  def `traverser withOrdering for nodes`: Unit =
     given(
       factory(
         0 ~> 4,
@@ -623,9 +607,8 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
           List(1) ::: List(11 to 13: _*) ::: List(2) ::: List(21 to 23: _*) :::
           List(3) ::: List(31 to 33: _*) ::: List(4) ::: List(41 to 43: _*)))
     }
-  }
 
-  def `traverser withOrdering for edges` {
+  def `traverser withOrdering for edges`: Unit = {
     val outerEdges = List(1 ~> 4 % 2, 1 ~> 2 % 5, 1 ~> 3 % 4, 3 ~> 6 % 4, 3 ~> 5 % 5, 3 ~> 7 % 2)
     given(factory(outerEdges: _*)) { g =>
       val root = g get 1
@@ -638,14 +621,13 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     }
   }
 
-  def `map Traverser result` {
+  def `map Traverser result`: Unit =
     given(Di_1.g) { _ =>
       val t = Di_1.g.nodes.head.outerNodeTraverser
       t map (_ + 1) should be(t.toList map (_ + 1))
     }
-  }
 
-  def `traverser for inner elements` {
+  def `traverser for inner elements`: Unit = {
     import Di_1._
     import g.{InnerEdge, InnerNode}
 
@@ -661,7 +643,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     }
   }
 
-  def `shortest path exists if path exists` {
+  def `shortest path exists if path exists`: Unit = {
     implicit val arbitraryWDiGraph = Arbitrary {
       import GraphGen.SmallInt._
       new GraphGen[Int, WDiEdge, G](factory, order, nodeGen, nodeDegrees, Set(WDiEdge), connected).apply

--- a/core/src/test/scala/scalax/collection/generator/TGraphGen.scala
+++ b/core/src/test/scala/scalax/collection/generator/TGraphGen.scala
@@ -19,7 +19,7 @@ class TGraphGenTest extends RefSpec with Matchers with PropertyChecks {
   implicit val config     = PropertyCheckConfiguration(minSuccessful = minSuccessful, maxDiscardedFactor = 1.0)
 
   object `nr of minimum successful tests` {
-    def `should be met` {
+    def `should be met`: Unit = {
       var count = 0
       forAll { (i: Int) =>
         count += 1
@@ -39,16 +39,15 @@ class TGraphGenTest extends RefSpec with Matchers with PropertyChecks {
         Set(DiEdge)
       ).outerNodeSet
 
-    def `should conform to the passed size` {
+    def `should conform to the passed size`: Unit =
       forAll(arbitrary[Set[Int]]) { (outerNodes: Set[Int]) =>
         outerNodes should have size (order)
       }
-    }
   }
 
   type IntDiGraph = Graph[Int, DiEdge]
 
-  def checkMetrics(g: IntDiGraph, metrics: GraphGen.Metrics[Int]) {
+  def checkMetrics(g: IntDiGraph, metrics: GraphGen.Metrics[Int]): Unit = {
     import metrics._
 
     val degrees                 = g.degreeSeq
@@ -69,20 +68,18 @@ class TGraphGenTest extends RefSpec with Matchers with PropertyChecks {
   object `tiny connected graph of [Int,DiEdge]` {
     implicit val arbitraryGraph = GraphGen.tinyConnectedIntDi[Graph](Graph)
 
-    def `should conform to tiny metrics` {
+    def `should conform to tiny metrics`: Unit =
       forAll(arbitrary[IntDiGraph]) { g: IntDiGraph =>
         checkMetrics(g, GraphGen.TinyInt)
       }
-    }
   }
 
   object `small connected graph of [Int,DiEdge]` {
     implicit val arbitraryGraph = GraphGen.smallConnectedIntDi[Graph](Graph)
 
-    def `should conform to small metrics` {
+    def `should conform to small metrics`: Unit =
       forAll(arbitrary[IntDiGraph]) { g: IntDiGraph =>
         checkMetrics(g, GraphGen.SmallInt)
       }
-    }
   }
 }

--- a/core/src/test/scala/scalax/collection/generator/TRandomGraph.scala
+++ b/core/src/test/scala/scalax/collection/generator/TRandomGraph.scala
@@ -42,10 +42,9 @@ class TRandomGraphTest extends RefSpec with Matchers {
       val graphConfig = graphCompanion.defaultConfig
     }
 
-  def checkOrder(g: Graph[Int, DiEdge])(implicit metrics: Metrics[Int]) {
+  def checkOrder(g: Graph[Int, DiEdge])(implicit metrics: Metrics[Int]): Unit =
     g.order should be(metrics.order)
-  }
-  def checkSize(g: Graph[Int, DiEdge])(implicit metrics: Metrics[Int]) {
+  def checkSize(g: Graph[Int, DiEdge])(implicit metrics: Metrics[Int]): Unit = {
     import metrics._
     val totalDegree = g.totalDegree
     val deviation   = totalDegree - expectedTotalDegree
@@ -63,7 +62,7 @@ class TRandomGraphTest extends RefSpec with Matchers {
     implicit def metrics: Metrics[Int] = normal
     val g                              = generator[Int, DiEdge, Graph](DiEdge, Graph, false).draw
 
-    def `should have expected size` {
+    def `should have expected size`: Unit = {
       checkOrder(g)
       checkSize(g)
     }
@@ -72,7 +71,7 @@ class TRandomGraphTest extends RefSpec with Matchers {
     implicit def metrics: Metrics[Int] = normal
     val g                              = generator[Int, DiEdge, MGraph](DiEdge, MGraph, true).draw
 
-    def `should have expected size` {
+    def `should have expected size`: Unit = {
       checkOrder(g)
       checkSize(g)
     }
@@ -86,7 +85,7 @@ class TRandomGraphTest extends RefSpec with Matchers {
 
     def `should have dense metrics`: Unit =
       dense should be('isDense)
-    def `should have expected size` {
+    def `should have expected size`: Unit = {
       checkOrder(g)
       checkSize(g)
     }
@@ -95,7 +94,7 @@ class TRandomGraphTest extends RefSpec with Matchers {
     implicit val metrics: Metrics[Int] = RandomGraph.TinyInt
     val g                              = generator[Int, WDiEdge, Graph](WDiEdge, Graph, true).draw
 
-    def `should have distinct weights` {
+    def `should have distinct weights`: Unit = {
       val weights = MSet.empty[Long] ++ (g.edges map (_.weight))
       weights.size should be(g.graphSize)
     }
@@ -104,7 +103,7 @@ class TRandomGraphTest extends RefSpec with Matchers {
     implicit val metrics: Metrics[Int] = RandomGraph.SmallInt
     val g                              = generator[Int, LDiEdge, Graph](LDiEdge, Graph, true).draw
 
-    def `should have distinct labels` {
+    def `should have distinct labels`: Unit = {
       val labels = MSet.empty[Any] ++ (g.edges map (_.label))
       labels.size should be(g.graphSize)
     }
@@ -117,11 +116,10 @@ class TRandomGraphTest extends RefSpec with Matchers {
     }
     var g: MGraph[Int, DiEdge] = _
 
-    def `should be fast enough` {
+    def `should be fast enough`: Unit =
       g = generator[Int, DiEdge, MGraph](DiEdge, MGraph, true).draw
-    }
 
-    def `should have expected size` {
+    def `should have expected size`: Unit = {
       checkOrder(g)
       checkSize(g)
     }

--- a/core/src/test/scala/scalax/collection/mutable/TArraySet.scala
+++ b/core/src/test/scala/scalax/collection/mutable/TArraySet.scala
@@ -27,17 +27,16 @@ class TArraySetTest extends RefSpec with Matchers {
   }
 
   object `ArraySet ` {
-    def `can grow` {
+    def `can grow`: Unit = {
       val arr = ArraySet.emptyWithHints[LkDiEdge[Int]]
       arr.capacity should be(hints.initialCapacity)
 
       val edges = new LkDiEdgeGenerator
-      def add(numberOfAdditions: Int, expectedCapacity: Int) {
+      def add(numberOfAdditions: Int, expectedCapacity: Int): Unit =
         for (i <- 0 until numberOfAdditions) {
           arr += edges.draw
           arr.capacity should be(expectedCapacity)
         }
-      }
 
       var toAdd, nextCapacity = hints.initialCapacity
       while (nextCapacity <= hints.hashTableThreshold) {
@@ -49,7 +48,7 @@ class TArraySetTest extends RefSpec with Matchers {
       arr.isArray should be(false)
     }
 
-    def `may be compacted` {
+    def `may be compacted`: Unit = {
       val edges = new LkDiEdgeGenerator
       val toAdd = hints.initialCapacity + 1
       val arr = ArraySet.emptyWithHints[LkDiEdge[Int]] ++=
@@ -58,10 +57,10 @@ class TArraySetTest extends RefSpec with Matchers {
       arr.capacity should be(toAdd)
 
     }
-    def `may be configured to be represented solely by a HashSet` {
+    def `may be configured to be represented solely by a HashSet`: Unit = {
       val edges = new LkDiEdgeGenerator
       val arr   = ArraySet.emptyWithHints[LkDiEdge[Int]](ArraySet.Hints.HashOnly)
-      def check {
+      def check: Unit = {
         arr.isArray should be(false)
         arr.capacity should be(0)
       }
@@ -74,14 +73,14 @@ class TArraySetTest extends RefSpec with Matchers {
       check
     }
 
-    def `supports hints` {
+    def `supports hints`: Unit = {
       val edges = new LkDiEdgeGenerator
       val arr   = ArraySet.emptyWithHints[LkDiEdge[Int]](ArraySet.Hints(0, 4, 8, 0))
       arr += edges.draw
       arr.capacity should be(4)
     }
 
-    def `supports hints properly when filtered` {
+    def `supports hints properly when filtered`: Unit = {
       val edges = new LkDiEdgeGenerator
       type E = LkDiEdge[Int]
       val arr  = ArraySet.emptyWithHints[E]
@@ -105,7 +104,7 @@ class TArraySetTest extends RefSpec with Matchers {
       filteredEven.hints.initialCapacity should equal(arr.size)
     }
 
-    def `is sortable` {
+    def `is sortable`: Unit = {
       val as  = ArraySet(3, 6, 0, -3)
       val sas = as.sorted
       sas.isInstanceOf[SortedArraySet[_]] should be(true)
@@ -119,7 +118,7 @@ class TArraySetTest extends RefSpec with Matchers {
       sas.range(-10, -4) should be(SortedArraySet.empty[Int])
     }
 
-    def `supports ++` {
+    def `supports ++` : Unit = {
       val a = ArraySet.empty[Int]
       val b = ArraySet(1)
       val c = ArraySet(2)
@@ -130,7 +129,7 @@ class TArraySetTest extends RefSpec with Matchers {
     }
 
     object `supports upsert` {
-      def upsert(toAdd: Int) {
+      def upsert(toAdd: Int): Unit = {
         val edges = new WUnDiEdgeGenerator
         val pos   = 1
         pos < toAdd should be(true)
@@ -151,12 +150,10 @@ class TArraySetTest extends RefSpec with Matchers {
         (arr upsert edges.draw) should be(true) // inserted
         arr.size should be(toAdd + 1)
       }
-      def `when represented by an Array` {
+      def `when represented by an Array`: Unit =
         upsert(hints.hashTableThreshold - 3)
-      }
-      def `when represented by a HashSet` {
+      def `when represented by a HashSet`: Unit =
         upsert(hints.hashTableThreshold + 3)
-      }
     }
   }
 }

--- a/core/src/test/scala/scalax/collection/mutable/TExtHashSet.scala
+++ b/core/src/test/scala/scalax/collection/mutable/TExtHashSet.scala
@@ -18,7 +18,7 @@ class TExtHashSetTest extends RefSpec with Matchers {
   val innerEdge              = graph get outerEdge
 
   object `Hash set extensions work properly` {
-    def `find entry` {
+    def `find entry`: Unit = {
       /* `inner.edge == outer` returns the expected result because Graph#InnerEdge.equal
        * is aware of the inner edge structure. The opposite will be false since, as a rule,
        * outer object types will not be Graph-aware with regard to their equal.
@@ -26,21 +26,21 @@ class TExtHashSetTest extends RefSpec with Matchers {
       def eq(outer: DiEdge[Int], inner: graph.EdgeT) = inner.edge == outer
       set.findElem(innerEdge, eq) should be(outerEdge)
     }
-    def `draw element` {
+    def `draw element`: Unit = {
       val randomElems = collection.mutable.Set.empty[DiEdge[Int]]
       val r           = new util.Random
       for (i <- 1 to (set.size * 32))
         randomElems += set draw r
       randomElems should have size (set.size)
     }
-    def `iterate over hashCodes` {
+    def `iterate over hashCodes`: Unit = {
       set.hashCodeIterator(-228876066).toList should have size (0)
       outerEdge.hashCode should be(innerEdge.hashCode)
       val elems = set.hashCodeIterator(outerEdge.hashCode).toList
       elems should have size (1)
       elems.head should be(outerEdge)
     }
-    def `iterate over duplicate hashCodes` {
+    def `iterate over duplicate hashCodes`: Unit = {
       case class C(i: Int, j: Int) {
         override def hashCode = i.##
       }

--- a/core/src/test/scala/scalax/time/TMicroBenchmark.scala
+++ b/core/src/test/scala/scalax/time/TMicroBenchmark.scala
@@ -12,7 +12,7 @@ class TMicroBenchmark extends RefSpec with Matchers {
   import MicroBenchmark._
 
   object `relativeTimes() reflects` {
-    def `relative execution times` {
+    def `relative execution times`: Unit = {
       val r = 1 to 20
       val relTimes = relativeTimes(warmUp = 2)(
         r.toList.sorted,
@@ -33,7 +33,7 @@ class TMicroBenchmark extends RefSpec with Matchers {
     }
   }
   object `relativeTime() roughly reflects` {
-    def `O(N) complexity of List.size` {
+    def `O(N) complexity of List.size`: Unit = {
       def fill(size: Int): (Int, List[Int]) = (size, List.fill(size)(0))
       val (small, big)                      = (fill(100), fill(1000))
 
@@ -45,7 +45,7 @@ class TMicroBenchmark extends RefSpec with Matchers {
       actual should ===(expected)
     }
   }
-  def `traversing immutable.Set takes marginally longer than mutable.Set` {
+  def `traversing immutable.Set takes marginally longer than mutable.Set`: Unit = {
     import scala.collection.mutable
     val size  = 10000
     val array = Array.tabulate(size)(identity)
@@ -55,7 +55,7 @@ class TMicroBenchmark extends RefSpec with Matchers {
 
     relativeTime(repetitions = 6)(m.sum == sum, imm.sum == sum) should be > (1.05f)
   }
-  def `traversing mutable.Set takes longer than mutable.BitSet` {
+  def `traversing mutable.Set takes longer than mutable.BitSet`: Unit = {
     import scala.collection.mutable
     val size  = 10000
     val array = Array.tabulate(size)(_ % (size / 10))

--- a/dot/src/main/scala/scalax/collection/io/dot/Export.scala
+++ b/dot/src/main/scala/scalax/collection/io/dot/Export.scala
@@ -139,21 +139,19 @@ class Export[N, E[X] <: EdgeLikeIn[X]](graph: Graph[N, E]) {
     (dotAST get root).innerNodeDownUpTraverser foreach {
       case (true, cluster) =>
         def format(kv: DotAttr): String = s"${kv.name} = ${kv.value}"
-        def outStmtList(stmtList: Seq[DotAttrStmt]) {
+        def outStmtList(stmtList: Seq[DotAttrStmt]): Unit =
           stmtList foreach {
             case DotAttrStmt(t, attrs) =>
               separate(true)
               res append t.toString
               res append s" [${attrs map format mkString ", "}]"
           }
-        }
-        def outIdList(kvList: Seq[DotAttr]) {
+        def outIdList(kvList: Seq[DotAttr]): Unit =
           kvList foreach { attr =>
             separate(true)
             res append format(attr)
           }
-        }
-        def outAttrList(attrList: Seq[DotAttr]) {
+        def outAttrList(attrList: Seq[DotAttr]): Unit =
           if (attrList.nonEmpty) {
             res append " ["
             attrList foreach { attr =>
@@ -166,7 +164,6 @@ class Export[N, E[X] <: EdgeLikeIn[X]](graph: Graph[N, E]) {
             res delete (res.size - 2, res.size)
             res append ']'
           }
-        }
         val head = cluster.dotGraph.headToString
         val (graphStmtList, graphKvList) = cluster.dotGraph match {
           case DotRootGraph(_, _, _, attrStmts, kvList) =>

--- a/dot/src/test/scala/scalax/collection/io/dot/TExport.scala
+++ b/dot/src/test/scala/scalax/collection/io/dot/TExport.scala
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith
 @RunWith(classOf[JUnitRunner])
 class TExportTest extends RefSpec with Matchers {
 
-  def `Example at http://en.wikipedia.org/wiki/DOT_language will be produced` {
+  def `Example at http://en.wikipedia.org/wiki/DOT_language will be produced`: Unit = {
 
     implicit def toLDiEdge[N](diEdge: DiEdge[N]) = LDiEdge(diEdge._1, diEdge._2)("")
     val g = Graph[String, LDiEdge](
@@ -113,7 +113,7 @@ class TExportTest extends RefSpec with Matchers {
       be(expected_2))
   }
 
-  def `DOT headers are covered even in edge cases` {
+  def `DOT headers are covered even in edge cases`: Unit = {
     val g = Graph.empty[String, UnDiEdge]
     val dot = g.toDot(
       dotRoot = DotRootGraph(
@@ -130,7 +130,7 @@ class TExportTest extends RefSpec with Matchers {
     dot should be(expected)
   }
 
-  def `Directed hyperedges may be mapped to multiple directed DOT edges` {
+  def `Directed hyperedges may be mapped to multiple directed DOT edges`: Unit = {
     val hg   = Graph(1 ~> 2 ~> 3)
     val root = DotRootGraph(directed = true, id = None)
     val dot = hg.toDot(
@@ -149,7 +149,7 @@ class TExportTest extends RefSpec with Matchers {
     sortMid(dot) should be(expected)
   }
 
-  def `Colons (':') in node_id's are handeled correctly` {
+  def `Colons (':') in node_id's are handeled correctly`: Unit = {
     def struct(i: Int) = s"struct$i"
     import implicits._, Record._
     val (f0, f1, f2, here) = ("f0", "f1", "f2", "here")
@@ -207,7 +207,7 @@ class TExportTest extends RefSpec with Matchers {
     sortMid(dot) should be(expected)
   }
 
-  def `doubly-nested subgraphs #69` {
+  def `doubly-nested subgraphs #69`: Unit = {
     import scalax.collection.Graph
     import scalax.collection.GraphEdge.DiEdge
     import scalax.collection.io.dot.implicits._

--- a/json/src/main/scala/scalax/collection/io/json/descriptor/Descriptor.scala
+++ b/json/src/main/scala/scalax/collection/io/json/descriptor/Descriptor.scala
@@ -52,7 +52,7 @@ class Descriptor[N](val defaultNodeDescriptor: NodeDescriptor[N],
                     namedNodeDescriptors: Iterable[NodeDescriptor[N]] = Seq.empty[NodeDescriptor[N]],
                     namedEdgeDescriptors: Iterable[GenEdgeDescriptor[N]] = Seq.empty[GenEdgeDescriptor[N]],
                     val sectionIds: SectionId = DefaultSectionId) {
-  def requireUniqueTypeIds(descriptors: Iterable[TypeId]) {
+  def requireUniqueTypeIds(descriptors: Iterable[TypeId]): Unit = {
     def duplicateTypeId =
       (namedNodeDescriptors.map(_.typeId).toList).sorted sliding 2 find
         (strings => if (strings.size == 2) strings.head == strings.tail else false)

--- a/json/src/main/scala/scalax/collection/io/json/serializer/EdgeSerializers.scala
+++ b/json/src/main/scala/scalax/collection/io/json/serializer/EdgeSerializers.scala
@@ -113,13 +113,12 @@ class WLEdgeSerializer[L: Manifest](labelSerializers: Serializer[L]*)
   }
 }
 trait HyperEdgeChecker {
-  final def checkNodeIds(jsonIds: List[JValue], parameters: HyperEdgeNodeIds) {
+  final def checkNodeIds(jsonIds: List[JValue], parameters: HyperEdgeNodeIds): Unit =
     jsonIds.size match {
       case size if size < 2                => throw err(InsufficientNodes, jsonIds.toString)
       case size if size != parameters.size => throw err(UnexpectedNodeId, jsonIds.toString)
       case _                               => None
     }
-  }
   final protected def prepareNodes(jsonIds: List[JValue]): List[String] = {
     val par = jsonIds collect { case JString(nId) => nId }
     checkNodeIds(jsonIds, par)

--- a/json/src/test/scala/demo/TJsonDemo.scala
+++ b/json/src/test/scala/demo/TJsonDemo.scala
@@ -41,7 +41,7 @@ class TJsonDemoTest extends RefSpec with Matchers {
   }
 
   object `When calling JSON import/export ` {
-    def `it is required that proper node descriptors are passed` {
+    def `it is required that proper node descriptors are passed`: Unit = {
       val quickJson = new Descriptor[Library](
         defaultNodeDescriptor = authorDescriptor,
         defaultEdgeDescriptor = DiHyper.descriptor[Library]()
@@ -52,7 +52,7 @@ class TJsonDemoTest extends RefSpec with Matchers {
         }
       caught.msg should be("""No 'NodeDescriptor' capable of processing type "demo.Book" found.""")
     }
-    def `it is required that proper edge descriptors are passed` {
+    def `it is required that proper edge descriptors are passed`: Unit = {
       val quickJson = new Descriptor[Library](
         defaultNodeDescriptor = authorDescriptor,
         defaultEdgeDescriptor = DiHyper.descriptor[Library](),
@@ -77,7 +77,7 @@ class TJsonDemoTest extends RefSpec with Matchers {
         namedEdgeDescriptors = Seq(Di.descriptor[Library]())
       )
     }
-    def `export works fine` {
+    def `export works fine`: Unit = {
       val exported = library.toJson(Named.descriptor)
 
       import net.liftweb.json._
@@ -116,7 +116,7 @@ class TJsonDemoTest extends RefSpec with Matchers {
           }
         }*/
     }
-    def `importing the exported JSON yields an equal graph` {
+    def `importing the exported JSON yields an equal graph`: Unit = {
       val expLibrary = library.toJson(Named.descriptor)
       Graph.fromJson[Library, HyperEdge](expLibrary, Named.descriptor) should equal(library)
     }
@@ -160,7 +160,7 @@ class TJsonDemoTest extends RefSpec with Matchers {
         namedEdgeDescriptors = Seq(Di.descriptor[Library](Some(new EdgeSerializer)))
       )
     }
-    def `export works fine` {
+    def `export works fine`: Unit = {
       val exported = library.toJson(Positioned.descriptor)
 
       import net.liftweb.json._
@@ -178,7 +178,7 @@ class TJsonDemoTest extends RefSpec with Matchers {
         }
      */
     }
-    def `importing the exported JSON yields an equal graph` {
+    def `importing the exported JSON yields an equal graph`: Unit = {
       val expLibrary = library.toJson(Positioned.descriptor)
       Graph.fromJson[Library, HyperEdge](expLibrary, Positioned.descriptor) should equal(library)
     }

--- a/json/src/test/scala/scalax/collection/io/json/TCustomEdge.scala
+++ b/json/src/test/scala/scalax/collection/io/json/TCustomEdge.scala
@@ -53,12 +53,10 @@ class TCustomEdge[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, 
     Transition("Menu", "Settings", 'S', NoneModifier))
 
   object `JSON import/export of graphs with custom edges works fine` {
-    def `when importing` {
+    def `when importing`: Unit =
       factory.fromJson[String, Transition](jsonText, descriptor) should be(graph)
-    }
-    def `when reimporting` {
+    def `when reimporting`: Unit =
       factory.fromJson[String, Transition](graph.toJson(descriptor), descriptor) should be(graph)
-    }
   }
 }
 

--- a/json/src/test/scala/scalax/collection/io/json/TDefaultSerialization.scala
+++ b/json/src/test/scala/scalax/collection/io/json/TDefaultSerialization.scala
@@ -42,15 +42,15 @@ class TDefaultSerialization[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with Gra
   }
 
   object `JSON import/export of node classes not known at compilation time works fine` {
-    def `when exporting` {
+    def `when exporting`: Unit = {
       import Fixture._
       graph.toJson(descriptor(extClasses)) should be(jsonText)
     }
-    def `when importing` {
+    def `when importing`: Unit = {
       import Fixture._
       factory.fromJson[Node, DiEdge](jsonText, descriptor(extClasses)) should be(graph)
     }
-    def `when reimporting` {
+    def `when reimporting`: Unit = {
       import Fixture._
       factory.fromJson[Node, DiEdge](graph.toJson(descriptor(extClasses)), descriptor(extClasses)) should be(graph)
     }

--- a/json/src/test/scala/scalax/collection/io/json/TJson.scala
+++ b/json/src/test/scala/scalax/collection/io/json/TJson.scala
@@ -55,7 +55,7 @@ class TJsonTest[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E,
           )
         val graph = factory("A" ~ "B", "B" ~ "C", ("A" ~%#> "B")(3), ("B" ~%#> "C")(4), "X" ~ "Y", "Y" ~ "A")
       }
-      def `on parsing` {
+      def `on parsing`: Unit = {
         import FixtureMixed._
         val lists = graphParse(jsonText, descriptor).toList
 
@@ -138,12 +138,12 @@ class TJsonTest[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E,
           case _ => fail
         }
       }
-      def `on importing` {
+      def `on importing`: Unit = {
         import FixtureMixed._
         val g = factory.fromJson[String, UnDiEdge](jsonText, descriptor)
         g should equal(graph)
       }
-      def `on reimporting` {
+      def `on reimporting`: Unit = {
         import FixtureMixed._
         val g = factory.fromJson[String, UnDiEdge](jsonText, descriptor)
         factory.fromJson[String, UnDiEdge](g.toJson(descriptor), descriptor) should equal(g)
@@ -164,12 +164,12 @@ class TJsonTest[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E,
             }""".filterNot(_.isWhitespace)
           val descriptor = new Descriptor[String](StringNodeDescriptor, LDi.descriptor[String, String](aLabel = ""))
         }
-        def `on importing` {
+        def `on importing`: Unit = {
           import FixtureLEdge._
           val g = factory.fromJson[String, LDiEdge](jsonText, descriptor)
           g should equal(graph)
         }
-        def `on reimporting` {
+        def `on reimporting`: Unit = {
           import FixtureLEdge._
           val g = factory.fromJson[String, LDiEdge](jsonText, descriptor)
           factory.fromJson[String, LDiEdge](g.toJson(descriptor), descriptor) should equal(g)
@@ -188,12 +188,12 @@ class TJsonTest[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E,
             StringNodeDescriptor,
             LDi.descriptor[String, String]("", Some(new LEdgeSerializer[String](new StringSerializer))))
         }
-        def `on importing` {
+        def `on importing`: Unit = {
           import FixtureLEdgeCustom._
           val g = factory.fromJson[String, LDiEdge](jsonText, descriptor)
           g should equal(graph)
         }
-        def `on reimporting` {
+        def `on reimporting`: Unit = {
           import FixtureLEdgeCustom._
           val g = factory.fromJson[String, LDiEdge](jsonText, descriptor)
           factory.fromJson[String, LDiEdge](g.toJson(descriptor), descriptor) should equal(g)
@@ -219,12 +219,12 @@ class TJsonTest[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E,
         )
         val graph = factory(("A" ~%+> "B")(100, "CLabel-1"), ("B" ~%+> "A")(200, "CLabel-2"))
       }
-      def `on importing` {
+      def `on importing`: Unit = {
         import FixtureWLEdgeCustom._
         val g = factory.fromJson[String, WLDiEdge](jsonText, descriptor)
         g should equal(graph)
       }
-      def `on reimporting` {
+      def `on reimporting`: Unit = {
         import FixtureWLEdgeCustom._
         val g = factory.fromJson[String, WLDiEdge](jsonText, descriptor)
         factory.fromJson[String, WLDiEdge](g.toJson(descriptor), descriptor) should equal(g)
@@ -235,7 +235,7 @@ class TJsonTest[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E,
 
     object `hypergraphs ` {
       object `with weighted labeled edges using custom edge desriptors` {
-        def `on importing` {
+        def `on importing`: Unit = {
           val jsonText = s"""
             { "nodes" : [["A"], ["B"], ["C"]],
               "edges": [
@@ -260,7 +260,7 @@ class TJsonTest[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E,
     }
     object `directed hypergraphs` {
       object `using default edge desriptors` {
-        def `on exporting` {
+        def `on exporting`: Unit = {
           val g = factory("B" ~> "A" ~> "C")
           val descr =
             new Descriptor[String](StringNodeDescriptor, DiHyper.descriptor[String](Some(new HyperEdgeSerializer)))
@@ -287,7 +287,7 @@ class TJsonTest[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E,
           )
           val graph = factory[String, DiHyperEdge](DiHyperEdge("A", "B"), "B" ~> "A" ~> "C")
         }
-        def `on importing` {
+        def `on importing`: Unit = {
           import FixtureDiHyperEdgeCustom._
           val g = factory.fromJson[String, DiHyperEdge](
             jsonText,
@@ -298,7 +298,7 @@ class TJsonTest[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E,
           )
           g should equal(graph)
         }
-        def `on reimporting` {
+        def `on reimporting`: Unit = {
           import FixtureDiHyperEdgeCustom._
           val g = factory.fromJson[String, DiHyperEdge](jsonText, descriptor)
           factory.fromJson[String, DiHyperEdge](g.toJson(descriptor), descriptor) should equal(g)

--- a/json/src/test/scala/scalax/collection/io/json/serializer/TGraphSerializer.scala
+++ b/json/src/test/scala/scalax/collection/io/json/serializer/TGraphSerializer.scala
@@ -51,15 +51,15 @@ class TGraphSerializer[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLik
   }
 
   object `JSON serialization of any class containing a graph works fine` {
-    def `when exporting` {
+    def `when exporting`: Unit = {
       val g = factory.fromJson[String, WDiEdge](graphJsonText, descriptor)
       g should equal(graph)
     }
-    def `when reimporting` {
+    def `when reimporting`: Unit = {
       val g = factory.fromJson[String, WDiEdge](graphJsonText, descriptor)
       factory.fromJson[String, WDiEdge](g.toJson(descriptor), descriptor) should equal(g)
     }
-    def `when decomposing and parsing` {
+    def `when decomposing and parsing`: Unit = {
       import ContainerFixture._
 
       implicit val format: Formats = DefaultFormats +


### PR DESCRIPTION
The procedure syntax was deprecated in scala/scala#3076

The new scalac options trigger now warnings when using the procedure syntax.

All changes, aside sbt files, were made by scalafix and scalafmt.

This is an updated supset of #132. 