### PR TITLE
Remove unused imports.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,11 @@ lazy val defaultSettings = Defaults.coreDefaultSettings ++ Seq(
   scalaVersion := Version.compiler_2_12,
   crossScalaVersions := Seq(scalaVersion.value, Version.compiler_2_11),
   organization := "org.scala-graph",
+  scalacOptions ++= Seq(
+    "-Ywarn-unused:imports",
+    "-Yrangepos"
+  ),
+  addCompilerPlugin(scalafixSemanticdb),
   Test / parallelExecution := false,
   Compile / doc / scalacOptions ++=
     Opts.doc.title(name.value) ++

--- a/constrained/src/main/scala/scalax/collection/constrained/Constraint.scala
+++ b/constrained/src/main/scala/scalax/collection/constrained/Constraint.scala
@@ -1,7 +1,7 @@
 package scalax.collection.constrained
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
-import scala.language.{higherKinds, postfixOps}
+import scala.language.higherKinds
 import scala.collection.Set
 
 import scalax.collection.GraphPredef._

--- a/constrained/src/main/scala/scalax/collection/constrained/ConstraintOp.scala
+++ b/constrained/src/main/scala/scalax/collection/constrained/ConstraintOp.scala
@@ -1,6 +1,6 @@
 package scalax.collection.constrained
 
-import scala.language.{higherKinds, postfixOps}
+import scala.language.higherKinds
 import scala.collection.Set
 import scala.collection.mutable.{Map => MMap}
 

--- a/constrained/src/main/scala/scalax/collection/constrained/constraints/NoneConstraint.scala
+++ b/constrained/src/main/scala/scalax/collection/constrained/constraints/NoneConstraint.scala
@@ -1,7 +1,7 @@
 package scalax.collection.constrained
 package constraints
 
-import scala.language.{higherKinds, postfixOps}
+import scala.language.higherKinds
 
 import scalax.collection.GraphPredef._
 

--- a/constrained/src/main/scala/scalax/collection/constrained/generic/Graph.scala
+++ b/constrained/src/main/scala/scalax/collection/constrained/generic/Graph.scala
@@ -2,7 +2,7 @@ package scalax.collection.constrained
 package generic
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.language.{higherKinds, postfixOps}
+import scala.language.higherKinds
 import scala.collection.mutable.Builder
 import scala.reflect.ClassTag
 

--- a/constrained/src/main/scala/scalax/collection/constrained/immutable/AdjacencyListGraph.scala
+++ b/constrained/src/main/scala/scalax/collection/constrained/immutable/AdjacencyListGraph.scala
@@ -2,9 +2,9 @@ package scalax.collection.constrained
 package immutable
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
-import scala.language.{higherKinds, postfixOps}
+import scala.language.higherKinds
 
-import scalax.collection.GraphPredef.{EdgeLikeIn, InParam, OuterEdge, OuterNode}
+import scalax.collection.GraphPredef.EdgeLikeIn
 import scalax.collection.immutable.{AdjacencyListGraph => SimpleAdjacencyListGraph}
 import scalax.collection.config.{AdjacencyListArrayConfig, GraphConfig}
 

--- a/constrained/src/main/scala/scalax/collection/constrained/immutable/Graph.scala
+++ b/constrained/src/main/scala/scalax/collection/constrained/immutable/Graph.scala
@@ -3,21 +3,15 @@ package immutable
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
-import scala.language.{higherKinds, postfixOps}
+import scala.language.higherKinds
 import scala.collection.Set
-import scala.collection.generic.CanBuildFrom
 import scala.reflect.ClassTag
 
-import scalax.collection.{Graph => CommonGraph}
-import scalax.collection.GraphEdge.{EdgeCompanionBase, EdgeLike}
-import scalax.collection.GraphPredef.{EdgeLikeIn, InParam, Param}
+import scalax.collection.GraphPredef.EdgeLikeIn
 import scalax.collection.GraphTraversalImpl
 import scalax.collection.mutable.ArraySet
-import scalax.collection.generic.GraphCompanion
-import scalax.collection.config.AdjacencyListArrayConfig
 
-import generic.{GraphConstrainedCompanion, ImmutableGraphCompanion}
-import config.ConstrainedConfig
+import generic.ImmutableGraphCompanion
 import PreCheckFollowUp._
 
 trait Graph[N, E[X] <: EdgeLikeIn[X]]

--- a/constrained/src/main/scala/scalax/collection/constrained/mutable/AdjacencyListGraph.scala
+++ b/constrained/src/main/scala/scalax/collection/constrained/mutable/AdjacencyListGraph.scala
@@ -1,7 +1,7 @@
 package scalax.collection.constrained
 package mutable
 
-import scala.language.{higherKinds, postfixOps}
+import scala.language.higherKinds
 import scala.collection.Set
 
 import scalax.collection.GraphPredef.EdgeLikeIn

--- a/constrained/src/main/scala/scalax/collection/constrained/mutable/package.scala
+++ b/constrained/src/main/scala/scalax/collection/constrained/mutable/package.scala
@@ -1,6 +1,6 @@
 package scalax.collection.constrained
 
-import scala.language.{higherKinds, postfixOps}
+import scala.language.higherKinds
 
 /** Mutable constrained graph templates.
   *
@@ -9,7 +9,6 @@ import scala.language.{higherKinds, postfixOps}
 package object mutable {
   import scalax.collection.GraphPredef._, scalax.collection.GraphEdge._
   import scalax.collection.mutable.ArraySet
-  import constraints._
   import generic._
 
   /** Enables to quickly assemble mutable constrained graph companion modules. Example:

--- a/core/src/main/scala/scala/collection/Facades.scala
+++ b/core/src/main/scala/scala/collection/Facades.scala
@@ -1,7 +1,5 @@
 package scala.collection
 
-import scala.collection.generic.{CanBuildFrom, FilterMonadic}
-
 /** Wraps `t` to a [[scala.collection.Seq Seq]]. It helps to avoid the creation of a copy
   *  of the elements of `t` when passing `t` to repeated parameters of type `A`.
   *  `apply` is O(N).

--- a/core/src/main/scala/scalax/collection/Graph.scala
+++ b/core/src/main/scala/scalax/collection/Graph.scala
@@ -1,15 +1,13 @@
 package scalax.collection
 
 import language.higherKinds
-import collection.{GenTraversable, GenTraversableOnce, SetLike}
-import collection.generic.GenericCompanion
+import collection.{GenTraversableOnce, SetLike}
 import scala.reflect.ClassTag
 
 import GraphPredef.{EdgeLikeIn, InParam, InnerEdgeParam, InnerNodeParam, OutParam, OuterEdge, OuterNode, Param}
-import GraphEdge.{DiEdge, DiHyperEdgeLike, EdgeCompanionBase, EdgeLike, Keyed, UnDiEdge}
+import GraphEdge.{DiEdge, DiHyperEdgeLike, Keyed, UnDiEdge}
 import generic.{GraphCompanion, GraphCoreCompanion}
 import config.GraphConfig
-import io._
 
 /** A template trait for graphs.
   *

--- a/core/src/main/scala/scalax/collection/GraphDegree.scala
+++ b/core/src/main/scala/scalax/collection/GraphDegree.scala
@@ -4,8 +4,7 @@ import language.{higherKinds, postfixOps}
 import collection.{SortedMap, SortedSet}
 import collection.mutable.{Map => MutableMap}
 
-import GraphPredef.{EdgeLikeIn, InnerEdgeParam, InnerNodeParam, NodeParam, OuterNode}
-import GraphEdge.EdgeLike
+import GraphPredef.EdgeLikeIn
 
 /** A trait for graph degree calculations.
   *

--- a/core/src/main/scala/scalax/collection/GraphEdge.scala
+++ b/core/src/main/scala/scalax/collection/GraphEdge.scala
@@ -3,7 +3,7 @@ package scalax.collection
 import language.higherKinds
 import scala.annotation.{switch, tailrec}
 
-import GraphPredef.{InnerNodeParam, OuterEdge}
+import GraphPredef.OuterEdge
 import edge.LBase.LEdge
 
 /** Container for basic edge types to be used in the context of `Graph`.

--- a/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
+++ b/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
@@ -1,6 +1,6 @@
 package scalax.collection
 
-import language.{higherKinds, implicitConversions}
+import language.higherKinds
 import scala.annotation.{switch, tailrec}
 import scala.collection.{AbstractTraversable, EqSetFacade}
 import scala.collection.mutable.{ArrayBuffer, Buffer, ArrayStack => Stack, Map => MMap}

--- a/core/src/main/scala/scalax/collection/edge/Base.scala
+++ b/core/src/main/scala/scalax/collection/edge/Base.scala
@@ -314,7 +314,7 @@ object WLkBase {
 
 /** Base traits for key-weighted and key-labeled edges. */
 object WkLkBase {
-  import WLBase._, WkBase._, LkBase._
+  import WLBase._
   trait WkLkEdge[+N] extends WLEdge[N] { this: EdgeLike[N] with Eq =>
     override protected def equals(other: EdgeLike[_]) = other match {
       case that: WkLkEdge[_] =>

--- a/core/src/main/scala/scalax/collection/edge/Edges.scala
+++ b/core/src/main/scala/scalax/collection/edge/Edges.scala
@@ -1,7 +1,6 @@
 package scalax.collection.edge
 
 import scalax.collection.GraphEdge._, scalax.collection.GraphPredef._
-import scalax.collection.Graph
 import WBase._, LBase._
 
 // ------------------------------------------------------------------------- W*

--- a/core/src/main/scala/scalax/collection/edge/HyperEdges.scala
+++ b/core/src/main/scala/scalax/collection/edge/HyperEdges.scala
@@ -1,7 +1,6 @@
 package scalax.collection.edge
 
 import scalax.collection.GraphEdge._, scalax.collection.GraphPredef._
-import scalax.collection.Graph
 import WBase._, LBase._
 
 // ------------------------------------------------------------------------- W*

--- a/core/src/main/scala/scalax/collection/generator/RandomGraph.scala
+++ b/core/src/main/scala/scalax/collection/generator/RandomGraph.scala
@@ -2,8 +2,7 @@ package scalax.collection
 package generator
 
 import scala.language.higherKinds
-import scala.collection.mutable.{ArrayBuffer, ListBuffer, Set => MSet}
-import scala.math.pow
+import scala.collection.mutable.{ArrayBuffer, Set => MSet}
 import scala.util.Random
 import scala.reflect.ClassTag
 

--- a/core/src/main/scala/scalax/collection/generic/Graph.scala
+++ b/core/src/main/scala/scalax/collection/generic/Graph.scala
@@ -4,11 +4,10 @@ package generic
 import language.higherKinds
 import annotation.unchecked.uncheckedVariance
 import collection.generic.CanBuildFrom
-import collection.mutable.{Builder, ListBuffer}
+import collection.mutable.Builder
 import scala.reflect.ClassTag
 
-import GraphEdge.{EdgeCompanionBase, EdgeLike}
-import GraphPredef.{EdgeLikeIn, OuterNode, Param}
+import GraphPredef.{EdgeLikeIn, Param}
 import config.{CoreConfig, GraphConfig}
 import mutable.GraphBuilder
 

--- a/core/src/main/scala/scalax/collection/immutable/SortedArraySet.scala
+++ b/core/src/main/scala/scalax/collection/immutable/SortedArraySet.scala
@@ -2,7 +2,7 @@ package scalax.collection.immutable
 
 import scala.collection.{AbstractIterator, SortedSetLike}
 import scala.collection.immutable.SortedSet
-import scala.collection.generic.{CanBuildFrom, GenericCompanion, GenericSetTemplate, SortedSetFactory}
+import scala.collection.generic.{CanBuildFrom, SortedSetFactory}
 import compat.Platform.arraycopy
 
 @SerialVersionUID(1L)

--- a/core/src/main/scala/scalax/collection/mutable/ArraySet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/ArraySet.scala
@@ -3,7 +3,7 @@ package mutable
 
 import collection.SortedSet
 import collection.mutable.{SetLike => MutableSetLike}
-import collection.generic.{CanBuildFrom, FilterMonadic, GenericCompanion, GenericSetTemplate, MutableSetFactory}
+import collection.generic.{CanBuildFrom, GenericCompanion, GenericSetTemplate, MutableSetFactory}
 
 import interfaces.ExtSetMethods
 

--- a/core/src/main/scala/scalax/collection/mutable/EqHashMap.scala
+++ b/core/src/main/scala/scalax/collection/mutable/EqHashMap.scala
@@ -10,7 +10,6 @@ class EqHashMap[K <: AnyRef, V](_sizeHint: Int = EqHash.defCapacity)
     with EqHash[(K, V), EqHashMap[K, V]] {
 
   import EqHash.{defCapacity, evenHash}
-  import EqHashMap._
 
   final protected def sizeHint: Int = _sizeHint
   final protected def step          = 2

--- a/core/src/main/scala/scalax/collection/mutable/EqHashSet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/EqHashSet.scala
@@ -9,7 +9,6 @@ class EqHashSet[A <: AnyRef](_sizeHint: Int = EqHash.defCapacity)
     with EqHash[A, EqHashSet[A]] {
 
   import EqHash.{anyHash, defCapacity}
-  import EqHashSet._
 
   final protected def sizeHint: Int = _sizeHint
   final protected def step          = 1

--- a/core/src/main/scala/scalax/collection/mutable/ExtHashSet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/ExtHashSet.scala
@@ -3,7 +3,7 @@ package mutable
 
 import scala.util.Random
 import scala.collection.AbstractIterator
-import scala.collection.mutable.{Builder, GrowingBuilder, HashSet, Set, SetLike}
+import scala.collection.mutable.{GrowingBuilder, HashSet, Set, SetLike}
 import scala.collection.generic.{GenericSetTemplate, MutableSetFactory}
 
 import interfaces.ExtSetMethods

--- a/core/src/main/scala/scalax/collection/mutable/SimpleArraySet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/SimpleArraySet.scala
@@ -2,8 +2,8 @@ package scalax.collection
 package mutable
 
 import util.Random
-import scala.collection.{AbstractIterator, GenSet, SortedSet}
-import scala.collection.mutable.{SetLike => MutableSetLike, Builder, GrowingBuilder, ArrayBuffer}
+import scala.collection.{AbstractIterator, SortedSet}
+import scala.collection.mutable.{SetLike => MutableSetLike, GrowingBuilder}
 import scala.collection.generic.{CanBuildFrom, GenericCompanion, GenericSetTemplate, MutableSetFactory}
 import scala.compat.Platform.arraycopy
 

--- a/core/src/test/scala/custom/ExtNode.scala
+++ b/core/src/test/scala/custom/ExtNode.scala
@@ -9,9 +9,6 @@ import scala.reflect.ClassTag
 
 import scalax.collection._
 import scalax.collection.GraphPredef.{EdgeLikeIn, InParam, Param}
-import scalax.collection.GraphEdge._
-import scalax.collection.generic.GraphCompanion
-import scalax.collection.immutable.AdjacencyListBase
 import scalax.collection.mutable.ArraySet
 import config.AdjacencyListArrayConfig
 

--- a/core/src/test/scala/custom/TExtByImplicit.scala
+++ b/core/src/test/scala/custom/TExtByImplicit.scala
@@ -1,6 +1,6 @@
 package custom
 
-import language.{higherKinds, implicitConversions, postfixOps, reflectiveCalls}
+import language.{higherKinds, implicitConversions, reflectiveCalls}
 
 import scalax.collection.Graph
 import scalax.collection.GraphPredef._

--- a/core/src/test/scala/custom/TExtNode.scala
+++ b/core/src/test/scala/custom/TExtNode.scala
@@ -2,7 +2,7 @@ package custom
 
 import language.postfixOps
 
-import scalax.collection.GraphPredef._, scalax.collection.GraphEdge._
+import scalax.collection.GraphPredef._
 import immutable.{MyExtGraph => Graph}
 import mutable.{MyExtGraph => MutableGraph}
 

--- a/core/src/test/scala/custom/flight/TFlight.scala
+++ b/core/src/test/scala/custom/flight/TFlight.scala
@@ -1,13 +1,12 @@
 package custom.flight
 
-import language.{higherKinds, postfixOps}
+import language.higherKinds
 
 import scalax.collection.{Graph, GraphLike}
-import scalax.collection.GraphPredef._, scalax.collection.GraphEdge._
+import scalax.collection.GraphPredef._
 import scalax.collection.generic.GraphCoreCompanion
 
 import org.scalatest._
-import org.scalatest.Informer
 
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.refspec.RefSpec

--- a/core/src/test/scala/demo/Editing.scala
+++ b/core/src/test/scala/demo/Editing.scala
@@ -1,7 +1,6 @@
 package demo
 
 import scala.collection.SortedSet
-import scala.language.higherKinds
 
 import scalax.collection.GraphPredef._
 import scalax.collection.GraphEdge._
@@ -99,7 +98,6 @@ final class EditingTest extends RefSpec with Matchers {
 
       import scalax.collection.edge.LBase._
       object StringLabel extends LEdgeImplicits[String]
-      import StringLabel._
 
       (0 /: g.edges)((sum, e) =>
         e.edge match {

--- a/core/src/test/scala/demo/TGraphTest.scala
+++ b/core/src/test/scala/demo/TGraphTest.scala
@@ -154,7 +154,6 @@ object TGraphTest extends App {
     // Integrating with ScalaTest, limiting the minimum # of successful test
     import org.scalatest.Matchers
     import org.scalatest.prop.PropertyChecks
-    import org.scalatest.prop.Configuration.PropertyCheckConfiguration
     import org.scalatest.refspec.RefSpec
 
     class TGraphGenTest extends RefSpec with Matchers with PropertyChecks {

--- a/core/src/test/scala/demo/Traversing.scala
+++ b/core/src/test/scala/demo/Traversing.scala
@@ -145,7 +145,6 @@ c1 <- fc1
       val g = Graph(1 ~> 2, 1 ~> 3, 2 ~> 3, 3 ~> 4, 4 ~> 2)
   
       import g.ExtendedNodeVisitor
-      import scalax.collection.GraphTraversal._
 
       type ValDepth = (Int,Int)
       var info = List.empty[ValDepth]

--- a/core/src/test/scala/scalax/collection/Data.scala
+++ b/core/src/test/scala/scalax/collection/Data.scala
@@ -3,8 +3,6 @@ package scalax.collection
 import language.higherKinds
 
 import GraphPredef.{EdgeLikeIn, _}
-import GraphEdge._
-import edge._
 import edge.Implicits._
 
 abstract class TGraph[N, E[X] <: EdgeLikeIn[X], G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, G]](

--- a/core/src/test/scala/scalax/collection/TConnectivity.scala
+++ b/core/src/test/scala/scalax/collection/TConnectivity.scala
@@ -1,20 +1,16 @@
 package scalax.collection
 
 import scala.language.{higherKinds, postfixOps}
-import scala.collection.mutable.{ListBuffer, Stack}
 import scala.util.Random
 
 import GraphPredef._, GraphEdge._
-import GraphTraversal._, GraphTraversal.Parameters._
 import generic.GraphCoreCompanion
-import edge.WDiEdge, edge.WUnDiEdge, edge.Implicits._
+import edge.Implicits._
 import generator._, RandomGraph._
 
-import org.scalacheck._
 import org.scalatest._
 import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.PropertyChecks
-import org.scalatest.prop.Configuration.PropertyCheckConfiguration
 import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 

--- a/core/src/test/scala/scalax/collection/TEdge.scala
+++ b/core/src/test/scala/scalax/collection/TEdge.scala
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith
 
 import GraphPredef._, GraphEdge._, edge._, edge.LBase._, edge.Implicits._
 
-import custom.flight._, custom.flight.Helper._, custom.flight.Flight.ImplicitEdge
+import custom.flight._, custom.flight.Helper._
 
 @RunWith(classOf[JUnitRunner])
 class TEdgeTest extends RefSpec with Matchers {

--- a/core/src/test/scala/scalax/collection/TEdit.scala
+++ b/core/src/test/scala/scalax/collection/TEdit.scala
@@ -5,7 +5,6 @@ import scala.reflect.ClassTag
 
 import GraphPredef._, GraphEdge._
 import generic.GraphCompanion
-import config._
 
 import org.scalatest._
 import org.scalatest.refspec.RefSpec
@@ -188,7 +187,7 @@ class TEditMutable extends RefSpec with Matchers {
     }
     def `fulfill labeled edege equality` {
       import edge.Implicits._
-      import edge.{LDiEdge, LUnDiEdge}
+      import edge.LDiEdge
 
       type StringLabel = Option[String]
       val str                = "A"
@@ -206,7 +205,6 @@ class TEditMutable extends RefSpec with Matchers {
 
       type ListLabel = List[Int]
       object ListLabelImplicit extends LEdgeImplicits[ListLabel]
-      import ListLabelImplicit._
       implicit val factory = LDiEdge
       val listLabel        = List(1, 0, 1)
       g.addLEdge(3, 4)(listLabel) should be(true)
@@ -219,7 +217,7 @@ class TEditMutable extends RefSpec with Matchers {
     }
     def `fulfill labeled directed hyperedege equality` {
       import edge.Implicits._
-      import edge.{LDiHyperEdge, LHyperEdge}
+      import edge.LHyperEdge
 
       type StringLabel = String
       val outerLabels = Seq("A", "BC", "CDE")
@@ -233,7 +231,6 @@ class TEditMutable extends RefSpec with Matchers {
 
       import edge.LBase.{LEdgeImplicits}
       object StringLabelImplicit extends LEdgeImplicits[StringLabel]
-      import StringLabelImplicit._
       val innerLabels: collection.mutable.Set[_ >: StringLabel] =
         g.edges filter (_.isLabeled) map (_.label)
       innerLabels should have size (outerLabels.size)
@@ -252,7 +249,7 @@ class TEditMutable extends RefSpec with Matchers {
         ++= mutable.Graph(1 ~ 2)) should equal(gAfter)
     }
     def `are upsertable` {
-      import edge.LDiEdge, edge.LBase._
+      import edge.LDiEdge
       val (label, modLabel) = ("A", "B")
       val g                 = mutable.Graph(LDiEdge(1, 2)(label), LDiEdge(2, 3)(label))
 

--- a/core/src/test/scala/scalax/collection/TEquals.scala
+++ b/core/src/test/scala/scalax/collection/TEquals.scala
@@ -1,6 +1,5 @@
 package scalax.collection
 
-
 import GraphPredef._, GraphEdge._
 
 import org.scalatest.Matchers

--- a/core/src/test/scala/scalax/collection/TEquals.scala
+++ b/core/src/test/scala/scalax/collection/TEquals.scala
@@ -1,9 +1,7 @@
 package scalax.collection
 
-import language.{higherKinds, postfixOps}
 
 import GraphPredef._, GraphEdge._
-import generic.GraphCoreCompanion
 
 import org.scalatest.Matchers
 import org.scalatest.refspec.RefSpec

--- a/core/src/test/scala/scalax/collection/TOp.scala
+++ b/core/src/test/scala/scalax/collection/TOp.scala
@@ -1,6 +1,6 @@
 package scalax.collection
 
-import language.{higherKinds, postfixOps}
+import language.higherKinds
 
 import GraphPredef._, GraphEdge._
 import generic.GraphCoreCompanion

--- a/core/src/test/scala/scalax/collection/TTraversal.scala
+++ b/core/src/test/scala/scalax/collection/TTraversal.scala
@@ -1,12 +1,11 @@
 package scalax.collection
 
 import scala.language.{higherKinds, postfixOps}
-import scala.collection.mutable.{ListBuffer, Stack}
+import scala.collection.mutable.ListBuffer
 import scala.util.Random
 import GraphPredef._
 import GraphEdge._
 import GraphTraversal._
-import GraphTraversal.Parameters._
 import generic.GraphCoreCompanion
 import edge.WDiEdge
 import edge.WUnDiEdge
@@ -17,7 +16,6 @@ import Arbitrary.arbitrary
 import org.scalatest._
 import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.PropertyChecks
-import org.scalatest.prop.Configuration.PropertyCheckConfiguration
 import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 import scalax.collection.visualization.Visualizer

--- a/core/src/test/scala/scalax/collection/generator/TGraphGen.scala
+++ b/core/src/test/scala/scalax/collection/generator/TGraphGen.scala
@@ -1,21 +1,14 @@
 package scalax.collection
 package generator
 
-import scala.language.higherKinds
-import scala.util.Random
 
 import org.scalacheck.{Arbitrary, Gen}
 import Arbitrary.arbitrary
-import org.scalacheck.Prop.forAll
 import org.scalatest.Matchers
 import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.PropertyChecks
-import org.scalatest.prop.Configuration.PropertyCheckConfiguration
-import org.scalatest.prop.Checkers._
 
-import GraphPredef._, GraphEdge._
-import mutable.{Graph => MGraph}
-import generic.GraphCompanion
+import GraphEdge._
 
 import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith

--- a/core/src/test/scala/scalax/collection/generator/TGraphGen.scala
+++ b/core/src/test/scala/scalax/collection/generator/TGraphGen.scala
@@ -1,7 +1,6 @@
 package scalax.collection
 package generator
 
-
 import org.scalacheck.{Arbitrary, Gen}
 import Arbitrary.arbitrary
 import org.scalatest.Matchers

--- a/core/src/test/scala/scalax/collection/mutable/TArraySet.scala
+++ b/core/src/test/scala/scalax/collection/mutable/TArraySet.scala
@@ -1,9 +1,8 @@
 package scalax.collection
 package mutable
 
-import collection.mutable.{ListBuffer, Map => MutableMap, Set => MutableSet}
+import collection.mutable.{Set => MutableSet}
 
-import GraphPredef._, GraphEdge._
 import edge.LkDiEdge, edge.WUnDiEdge, edge.Implicits._
 import immutable.SortedArraySet
 

--- a/core/src/test/scala/scalax/collection/mutable/TExtHashSet.scala
+++ b/core/src/test/scala/scalax/collection/mutable/TExtHashSet.scala
@@ -1,7 +1,7 @@
 package scalax.collection
 package mutable
 
-import GraphPredef._, GraphEdge._
+import GraphEdge._
 
 import org.scalatest.Matchers
 import org.scalatest.refspec.RefSpec

--- a/core/src/test/scala/scalax/time/MicroBenchmark.scala
+++ b/core/src/test/scala/scalax/time/MicroBenchmark.scala
@@ -1,7 +1,6 @@
 package scalax.time
 
 import scala.language.implicitConversions
-import scala.collection.AbstractTraversable
 import scala.collection.mutable.ArrayBuffer
 
 /** Provides lightweight syntax for simple time measurement and the comparison of results.

--- a/dot/src/main/scala/scalax/collection/io/dot/Export.scala
+++ b/dot/src/main/scala/scalax/collection/io/dot/Export.scala
@@ -2,10 +2,8 @@ package scalax.collection
 package io.dot
 
 import scala.language.higherKinds
-import scala.collection.mutable.{Map => MMap, Set => MSet, StringBuilder}
-import scala.util.matching.Regex
+import scala.collection.mutable.{Set => MSet, StringBuilder}
 
-import mutable.{Graph => MGraph}
 import GraphPredef.EdgeLikeIn
 import GraphEdge.DiEdge
 

--- a/dot/src/test/scala/scalax/collection/io/dot/TExport.scala
+++ b/dot/src/test/scala/scalax/collection/io/dot/TExport.scala
@@ -1,7 +1,7 @@
 package scalax.collection
 package io.dot
 
-import language.{existentials, implicitConversions}
+import language.implicitConversions
 import scala.collection.SortedMap
 
 import GraphPredef._, GraphEdge._, edge.LDiEdge, edge.Implicits._

--- a/json/src/main/scala/scalax/collection/io/edge/Parameters.scala
+++ b/json/src/main/scala/scalax/collection/io/edge/Parameters.scala
@@ -1,7 +1,5 @@
 package scalax.collection.io.edge
 
-import scalax.collection.GraphEdge.CollectionKind
-
 object Types {
   type EdgeNodeIds      = (String, String)
   type HyperEdgeNodeIds = List[String]

--- a/json/src/main/scala/scalax/collection/io/json/descriptor/Descriptor.scala
+++ b/json/src/main/scala/scalax/collection/io/json/descriptor/Descriptor.scala
@@ -4,10 +4,6 @@ package descriptor
 import language.existentials
 import reflect.ClassTag
 
-import scalax.collection.GraphEdge._
-import scalax.collection.edge._, scalax.collection.edge.WBase._, scalax.collection.edge.LBase._,
-scalax.collection.edge.WLBase._
-
 import error.JsonGraphError._
 
 /** Contains string constants to denote node/edge sections in a JSON text.

--- a/json/src/main/scala/scalax/collection/io/json/descriptor/EdgeDescriptor.scala
+++ b/json/src/main/scala/scalax/collection/io/json/descriptor/EdgeDescriptor.scala
@@ -1,17 +1,15 @@
 package scalax.collection.io.json
 package descriptor
 
-import language.{existentials, higherKinds}
+import language.higherKinds
 import reflect.ClassTag
 
 import net.liftweb.json._
 
-import scalax.collection.GraphPredef._, scalax.collection.GraphEdge._, scalax.collection.Graph
+import scalax.collection.GraphPredef._, scalax.collection.GraphEdge._
 import scalax.collection.edge._, scalax.collection.edge.WBase._, scalax.collection.edge.LBase._,
 scalax.collection.edge.WLBase._, scalax.collection.edge.CBase._
 import scalax.collection.io.edge._
-
-import serializer._
 
 /** Generic base trait for any `*EdgeDescriptor` excluding edge types
   * to be used as type argument to collections containing edge descriptors

--- a/json/src/main/scala/scalax/collection/io/json/descriptor/NodeDescriptor.scala
+++ b/json/src/main/scala/scalax/collection/io/json/descriptor/NodeDescriptor.scala
@@ -1,12 +1,9 @@
 package scalax.collection.io.json
 package descriptor
 
-import language.existentials
-import reflect.ClassTag
-
 import net.liftweb.json._
 
-import error.JsonGraphError._, error.JsonGraphWarning._
+import error.JsonGraphError._
 
 /** Provides information on how to extract node data from a JValue and how to
   * decompose the node to a JValue.

--- a/json/src/main/scala/scalax/collection/io/json/descriptor/predefined/EdgeDescriptor.scala
+++ b/json/src/main/scala/scalax/collection/io/json/descriptor/predefined/EdgeDescriptor.scala
@@ -5,11 +5,8 @@ package predefined
 import net.liftweb.json._
 
 import scalax.collection.GraphEdge._
-import scalax.collection.edge._, scalax.collection.edge.WBase._, scalax.collection.edge.LBase._,
-scalax.collection.edge.WLBase._
+import scalax.collection.edge._
 import scalax.collection.io.edge._
-
-import serializer._
 
 trait PredefinedEdgeDescriptorBase {
   def typeId = this.toString + "Edge"

--- a/json/src/main/scala/scalax/collection/io/json/exp/Export.scala
+++ b/json/src/main/scala/scalax/collection/io/json/exp/Export.scala
@@ -7,9 +7,7 @@ import scala.collection.immutable.Iterable
 
 import net.liftweb.json._
 
-import error.JsonGraphError._, error.JsonGraphWarning._
-
-import scalax.collection.GraphPredef._, scalax.collection.GraphEdge.EdgeLike, scalax.collection.Graph
+import scalax.collection.GraphPredef._, scalax.collection.Graph
 
 import descriptor._
 

--- a/json/src/main/scala/scalax/collection/io/json/imp/Stream.scala
+++ b/json/src/main/scala/scalax/collection/io/json/imp/Stream.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable.ArrayBuffer
 import scalax.collection.GraphPredef._, scalax.collection.GraphEdge._
 import scalax.collection.edge._, scalax.collection.edge.WBase._, scalax.collection.edge.LBase._,
 scalax.collection.edge.WLBase._, scalax.collection.edge.CBase._
-import scalax.collection.io._, scalax.collection.io.edge._
+import scalax.collection.io.edge._
 
 import descriptor._
 import error.JsonGraphError._, error.JsonGraphWarning._

--- a/json/src/main/scala/scalax/collection/io/json/serializer/EdgeSerializers.scala
+++ b/json/src/main/scala/scalax/collection/io/json/serializer/EdgeSerializers.scala
@@ -3,10 +3,10 @@ package serializer
 
 import net.liftweb.json._
 
-import scalax.collection.GraphEdge.{Bag, CollectionKind}
+import scalax.collection.GraphEdge.Bag
 import scalax.collection.io.edge._, scalax.collection.io.edge.Types._
 
-import error.JsonGraphIssue, error.JsonGraphError._, error.JsonGraphWarning._
+import error.JsonGraphError._
 
 // TODO MappingException
 /** Lift-JSON `Serializer` to serialize `EdgeParameters` to JSON arrays of the form

--- a/json/src/test/scala/scalax/collection/io/json/TCustomEdge.scala
+++ b/json/src/test/scala/scalax/collection/io/json/TCustomEdge.scala
@@ -12,8 +12,7 @@ import scalax.collection.edge.CBase._
 import scalax.collection.io.edge.CEdgeParameters
 import scalax.collection.io.json.descriptor.CEdgeDescriptor
 
-import serializer._, imp._, imp.Parser.{parse => graphParse}, descriptor._, descriptor.predefined._,
-descriptor.Defaults._, exp.Export
+import descriptor._
 
 import org.scalatest._
 import org.scalatest.refspec.RefSpec

--- a/json/src/test/scala/scalax/collection/io/json/TDefaultSerialization.scala
+++ b/json/src/test/scala/scalax/collection/io/json/TDefaultSerialization.scala
@@ -2,13 +2,12 @@ package scalax.collection.io.json
 
 import language.higherKinds
 
-import net.liftweb.json._
 
 import scalax.collection._
 import scalax.collection.GraphPredef._, scalax.collection.GraphEdge._
 import scalax.collection.generic.GraphCoreCompanion
 
-import serializer._, imp._, descriptor._, descriptor.predefined._, descriptor.Defaults._, exp.Export
+import descriptor.predefined._
 
 import org.scalatest._
 import org.scalatest.refspec.RefSpec

--- a/json/src/test/scala/scalax/collection/io/json/TDefaultSerialization.scala
+++ b/json/src/test/scala/scalax/collection/io/json/TDefaultSerialization.scala
@@ -2,7 +2,6 @@ package scalax.collection.io.json
 
 import language.higherKinds
 
-
 import scalax.collection._
 import scalax.collection.GraphPredef._, scalax.collection.GraphEdge._
 import scalax.collection.generic.GraphCoreCompanion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
 addSbtPlugin("com.geirsson"            % "sbt-scalafmt"      % "1.5.1")
+addSbtPlugin("ch.epfl.scala"           % "sbt-scalafix"      % "0.9.5")


### PR DESCRIPTION
The new scalac options trigger now warnings when imports become unused.

All changes, aside sbt files, were made by scalafix and scalafmt.

This is an updated supset of #132.