### PR TITLE
Fix test compilation with JDK 11

### DIFF
--- a/core/src/test/scala/scalax/collection/generator/TRandomGraph.scala
+++ b/core/src/test/scala/scalax/collection/generator/TRandomGraph.scala
@@ -54,7 +54,7 @@ class TRandomGraphTest extends RefSpec with Matchers {
                  | isDense=$isDense,
                  | maxDev=$maxDegreeDeviation,
                  | deviation=$deviation,
-                 | (${100f * deviation / totalDegree}%2.2f percent)""".stripMargin.lines.mkString)
+                 | (${100f * deviation / totalDegree}%2.2f percent)""".stripMargin.linesIterator.mkString)
     totalDegree should (be >= (expectedTotalDegree - maxDegreeDeviation) and
     be <= (expectedTotalDegree + maxDegreeDeviation))
   }


### PR DESCRIPTION
Since JDK 11 the String class has a method lines. It prevents the implicit
conversion to RichString which provides a Scala specific lines method
for Strings.