### PR TITLE
Remove unused private things

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,7 @@ lazy val defaultSettings = Defaults.coreDefaultSettings ++ Seq(
     "-Ywarn-unused:imports",
     "-Yrangepos"
   ),
+  Compile / scalacOptions in compile += "-Ywarn-unused:privates",
   addCompilerPlugin(scalafixSemanticdb),
   Test / parallelExecution := false,
   Compile / doc / scalacOptions ++=

--- a/constrained/src/main/scala/scalax/collection/constrained/constraints/Acyclic.scala
+++ b/constrained/src/main/scala/scalax/collection/constrained/constraints/Acyclic.scala
@@ -75,8 +75,7 @@ class Acyclic[N, E[X] <: EdgeLikeIn[X], G <: Graph[N, E]](override val self: G) 
       if (graphAdd.isCyclic)
         PreCheckResult(Abort)
       else {
-        val found        = (for (n <- p.toOuterNodes) yield self find n) filter (_.isDefined)
-        val dockingNodes = Set()
+        val found = (for (n <- p.toOuterNodes) yield self find n) filter (_.isDefined)
         Result(PostCheck, (found map (_.get)) toSet)
       }
     } else PreCheckResult(PostCheck)

--- a/constrained/src/main/scala/scalax/collection/constrained/immutable/AdjacencyListGraph.scala
+++ b/constrained/src/main/scala/scalax/collection/constrained/immutable/AdjacencyListGraph.scala
@@ -100,8 +100,8 @@ trait AdjacencyListGraph[
     n,
     false,
     (outerNode: N, innerNode: NodeT) => {
-      var newNodes = nodes.toOuter.toBuffer
-      var newEdges = edges.toOuter.toBuffer
+      val newNodes = nodes.toOuter.toBuffer
+      val newEdges = edges.toOuter.toBuffer
       nodes.subtract(
         innerNode,
         false,

--- a/constrained/src/test/scala/scalax/collection/constrained/constraints/TAcyclic.scala
+++ b/constrained/src/test/scala/scalax/collection/constrained/constraints/TAcyclic.scala
@@ -2,7 +2,7 @@ package scalax.collection.constrained
 package constraints
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
-import scala.language.{higherKinds, postfixOps}
+import scala.language.higherKinds
 
 import org.scalatest._
 import org.scalatest.refspec.RefSpec

--- a/constrained/src/test/scala/scalax/collection/constrained/constraints/TConnected.scala
+++ b/constrained/src/test/scala/scalax/collection/constrained/constraints/TConnected.scala
@@ -1,12 +1,11 @@
 package scalax.collection.constrained
 package constraints
 
-import scala.language.{higherKinds, postfixOps}
+import scala.language.higherKinds
 
 import scalax.collection.GraphPredef._
 import scalax.collection.GraphEdge._
 import scalax.collection.{Graph => SimpleGraph}
-import PreCheckFollowUp._
 import generic.GraphConstrainedCompanion
 
 import org.scalatest._

--- a/core/src/main/scala/scalax/collection/GraphBase.scala
+++ b/core/src/main/scala/scalax/collection/GraphBase.scala
@@ -498,7 +498,7 @@ trait GraphBase[N, E[X] <: EdgeLikeIn[X]] extends Serializable { selfGraph =>
       * @return set of connecting edges including hooks.
       */
     def adjacents: Set[EdgeT] = {
-      var a = new mutable.EqHashMap[EdgeT, Null]
+      val a = new mutable.EqHashMap[EdgeT, Null]
       this foreach (n => n.edges foreach (e => a put (e, null)))
       a -= this
       new immutable.EqSet(a)

--- a/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
+++ b/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
@@ -607,7 +607,7 @@ trait GraphTraversalImpl[N, E[X] <: EdgeLikeIn[X]]
       def foreach[U](f: S => U): Unit = {
         enclosed(0) foreach f
         var i    = upper
-        var size = i
+        val size = i
         while (i > 0) {
           i -= 1
           f(s(i))

--- a/core/src/main/scala/scalax/collection/State.scala
+++ b/core/src/main/scala/scalax/collection/State.scala
@@ -20,10 +20,10 @@ protected trait State[N, E[X] <: EdgeLikeIn[X]] {
   import State._
 
   /** Flags in `inUse` refer to required but unclosed handles. */
-  private var inUse = new FlagStore
+  private val inUse = new FlagStore
 
   /** Flags in `dirty` refer to released handles with dirty flags at the nodes. */
-  private var dirty   = new FlagStore
+  private val dirty   = new FlagStore
   private val monitor = new Object with Serializable
 
   protected def dump(store: FlagStore): ExtBitSet = {

--- a/core/src/main/scala/scalax/collection/TraverserImpl.scala
+++ b/core/src/main/scala/scalax/collection/TraverserImpl.scala
@@ -6,7 +6,6 @@ import scala.collection.FilteredSet
 import scala.collection.generic.FilterMonadic
 import scala.collection.mutable.{ArrayBuffer, PriorityQueue, Queue, ArrayStack => Stack, Map => MMap}
 import scala.language.higherKinds
-import scala.math.abs
 
 import scalax.collection.GraphPredef.EdgeLikeIn
 import immutable.SortedArraySet
@@ -162,7 +161,6 @@ trait TraverserImpl[N, E[X] <: EdgeLikeIn[X]] {
           case a: ArraySet[A] => a.sorted(ordering)
           case t =>
             @inline def newArray(len: Int): Array[A] = new Array[B](len).asInstanceOf[Array[A]]
-            val size                                 = abs(maxOrEst)
             var cnt                                  = 0
             val arr =
               if (maxOrEst >= 0) {

--- a/core/src/main/scala/scalax/collection/immutable/AdjacencyListBase.scala
+++ b/core/src/main/scala/scalax/collection/immutable/AdjacencyListBase.scala
@@ -35,13 +35,6 @@ trait AdjacencyListBase[
 
     def edges: ArraySet[EdgeT]
 
-    final private def sizeHint(edgesSize: Int): Int =
-      if (isHyper) size * 2
-      else if (isDirected)
-        if (size < 8) size
-        else (size / 4) * 3
-      else size
-
     @inline final protected def nodeEqThis = (n: NodeT) => n eq this
     protected[collection] object Adj extends Serializable { // lazy adjacents
       @transient protected[collection] var _aHook: Option[(NodeT, EdgeT)] = _

--- a/core/src/main/scala/scalax/collection/mutable/EqHashMap.scala
+++ b/core/src/main/scala/scalax/collection/mutable/EqHashMap.scala
@@ -42,7 +42,6 @@ class EqHashMap[K <: AnyRef, V](_sizeHint: Int = EqHash.defCapacity)
   override def remove(key: K): Option[V] = (index(key): @switch) match {
     case i if i < 0 => None
     case i =>
-      val item = table(i)
       _size -= 1
       val oldValue = table(i + 1)
       table(i + 1) = null

--- a/core/src/main/scala/scalax/collection/mutable/EqHashSet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/EqHashSet.scala
@@ -59,7 +59,6 @@ class EqHashSet[A <: AnyRef](_sizeHint: Int = EqHash.defCapacity)
   override def remove(elem: A): Boolean = (index(elem): @switch) match {
     case i if i < 0 => false
     case i =>
-      val item = table(i)
       _size -= 1
       table(i) = null
       closeDeletion(i)

--- a/core/src/test/scala/scalax/collection/TEdit.scala
+++ b/core/src/test/scala/scalax/collection/TEdit.scala
@@ -126,7 +126,6 @@ class TEditMutable extends RefSpec with Matchers {
       val (one, two, three, oneOneTwo, oneTwoThree) = (1, 2, 3, 1 ~> 1 ~> 2, 1 ~> 2 ~> 3)
       val g                                         = mutable.Graph(oneOneTwo, oneTwoThree)
       val (n1, n2)                                  = (g get one, g get two)
-      val e112                                      = g get oneOneTwo
 
       (n2 diSuccessors) should be('isEmpty)
       (n1 diSuccessors) should be(Set(two, three))
@@ -204,7 +203,6 @@ class TEditMutable extends RefSpec with Matchers {
       }
 
       type ListLabel = List[Int]
-      object ListLabelImplicit extends LEdgeImplicits[ListLabel]
       implicit val factory = LDiEdge
       val listLabel        = List(1, 0, 1)
       g.addLEdge(3, 4)(listLabel) should be(true)
@@ -229,8 +227,7 @@ class TEditMutable extends RefSpec with Matchers {
       g.addLEdge(4, 5, 6)(outerLabels(2)) should be(true)
       g should have('order (6), 'graphSize (4))
 
-      import edge.LBase.{LEdgeImplicits}
-      object StringLabelImplicit extends LEdgeImplicits[StringLabel]
+      import edge.LBase.LEdgeImplicits
       val innerLabels: collection.mutable.Set[_ >: StringLabel] =
         g.edges filter (_.isLabeled) map (_.label)
       innerLabels should have size (outerLabels.size)
@@ -464,7 +461,6 @@ class TEdit[CC[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike[N, E, CC]
     def `EdgeAssoc ` {
       val e = 1 ~ 2
       e.isInstanceOf[UnDiEdge[Int]] should be(true)
-      val x = factory(3 ~ 4).nodes
       // Error in Scala compiler: assertion failed
       // Graph(3).nodes contains 3 //should be (true)
 

--- a/core/src/test/scala/scalax/collection/TState.scala
+++ b/core/src/test/scala/scalax/collection/TState.scala
@@ -1,7 +1,7 @@
 package scalax.collection
 
 import scala.language.postfixOps
-import scala.collection.mutable.{ListBuffer, Map => MutableMap}
+import scala.collection.mutable.{Map => MutableMap}
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.duration._
@@ -91,7 +91,7 @@ class TStateTest extends RefSpec with Matchers {
       )
       // statistics map with key = nrOfNodesCounted, value = frequency
       val stat = MutableMap.empty[Int, Int]
-      val a = Await.result(traversals, 1 seconds) foreach { cnt =>
+      Await.result(traversals, 1 seconds) foreach { cnt =>
         stat += cnt -> (stat.getOrElse(cnt, 0) + 1)
       }
       // each traversal must yield the same result
@@ -103,8 +103,7 @@ class TStateTest extends RefSpec with Matchers {
       def n(outer: Int) = g.node(outer)
       val (n1, n2)      = (n(2), n(5))
 
-      val times  = 200000
-      val errors = ListBuffer.empty[Int]
+      val times = 200000
       def run: Boolean =
         (1 to times).par forall { i =>
           (n1 pathTo n2).nonEmpty

--- a/core/src/test/scala/scalax/collection/TTraversal.scala
+++ b/core/src/test/scala/scalax/collection/TTraversal.scala
@@ -354,14 +354,11 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       val nodes     = ListBuffer[g.NodeT]()
       val edges     = ListBuffer[g.EdgeT]()
       val traverser = n(2).innerElemTraverser.withSubgraph(nodes = _ != 3)
-      traverser
-        .pathTo(n(1)) {
-          _ match {
-            case g.InnerNode(n) => nodes += n
-            case g.InnerEdge(e) => edges += e
-          }
-        }
-        .get
+      traverser.pathTo(n(1)) {
+        case g.InnerNode(n) => nodes += n
+        case g.InnerEdge(e) => edges += e
+      }
+
       nodes should be(List(n(2), n(1)))
       edges.toList.sorted(g.Edge.WeightOrdering) should be(List(eUnDi_2(1), eUnDi_2(5), eUnDi_2(0)))
     }

--- a/core/src/test/scala/scalax/collection/TTraversal.scala
+++ b/core/src/test/scala/scalax/collection/TTraversal.scala
@@ -180,7 +180,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       n1 pathUntil (_ == n1) should be(None)
 
       val n2 = g get 2
-      val p2 = n2 pathUntil (_ == n1) should be(None)
+      n2 pathUntil (_ == n1) should be(None)
 
       val n5       = g get 5
       val n6       = g get 6
@@ -345,18 +345,16 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
     def `calling BreadthFirst` = given(WUnDi_1.g) { _ =>
       check(BreadthFirst)
     }
-
-    private def floatWeight(e: g.EdgeT): Float = e.weight.toFloat
   }
 
   def `traverser with a visitor` {
     given(gUnDi_2) { g =>
       def n(value: Int) = g get value
 
-      var nodes     = ListBuffer[g.NodeT]()
-      var edges     = ListBuffer[g.EdgeT]()
+      val nodes     = ListBuffer[g.NodeT]()
+      val edges     = ListBuffer[g.EdgeT]()
       val traverser = n(2).innerElemTraverser.withSubgraph(nodes = _ != 3)
-      val p2_1_nNE3 = traverser
+      traverser
         .pathTo(n(1)) {
           _ match {
             case g.InnerNode(n) => nodes += n
@@ -433,7 +431,7 @@ final class TTraversal[G[N, E[X] <: EdgeLikeIn[X]] <: Graph[N, E] with GraphLike
       shp4.get.nodes.toList should be(List(jfc, fra, svx))
       shp4.get.edges.toList should be(List(flight("UA 8840"), flight("LH 1480")))
 
-      var visited = MSet[g.EdgeT]()
+      val visited = MSet[g.EdgeT]()
       (g get jfc).innerEdgeTraverser.shortestPathTo(g get lhr) { e: g.EdgeT =>
         visited += e
       }

--- a/core/src/test/scala/scalax/collection/generator/TGraphGen.scala
+++ b/core/src/test/scala/scalax/collection/generator/TGraphGen.scala
@@ -61,7 +61,6 @@ class TGraphGenTest extends RefSpec with Matchers with PropertyChecks {
     degrees.max should be <= (nodeDegrees.max + tolerableMaxExceed)
 
     val totalDegree = g.totalDegree
-    val deviation   = totalDegree - expectedTotalDegree
     totalDegree should (be >= (expectedTotalDegree - maxDegreeDeviation) and
     be <= (expectedTotalDegree + maxDegreeDeviation))
   }

--- a/json/src/main/scala/scalax/collection/io/json/imp/Stream.scala
+++ b/json/src/main/scala/scalax/collection/io/json/imp/Stream.scala
@@ -186,11 +186,8 @@ object Stream {
               buf += {
                 val params: HyperEdgeParameters =
                   d.extract(jsonEdge).asInstanceOf[HyperEdgeParameters]
-                val nodeIds = params.nodeIds map lookupNode
-                var rest    = nodeIds
-                val _1      = rest.head; rest = rest.tail
-                val _2      = rest.head; rest = rest.tail
-                val _n      = rest
+                val nodeIds          = params.nodeIds map lookupNode
+                val _1 +: _2 +: rest = nodeIds
                 d.edgeCompanion(_1, _2, rest: _*)
               }
 

--- a/json/src/main/scala/scalax/collection/io/json/serializer/EdgeSerializers.scala
+++ b/json/src/main/scala/scalax/collection/io/json/serializer/EdgeSerializers.scala
@@ -13,7 +13,6 @@ import error.JsonGraphError._
   * ["<n1>","<n2>"] and reversely where <n1> and <n2> represent the node-Ids.
   */
 class EdgeSerializer extends Serializer[EdgeParameters] {
-  private val clazz = classOf[EdgeParameters]
   override def deserialize(implicit format: Formats) = {
     case (TypeInfo(clazz, _), json) =>
       json match {
@@ -35,7 +34,6 @@ class EdgeSerializer extends Serializer[EdgeParameters] {
   * and `<weight>` a JSON number mapping to `Double`.
   */
 class WEdgeSerializer extends Serializer[WEdgeParameters] {
-  private val clazz = classOf[WEdgeParameters]
   override def deserialize(implicit format: Formats) = {
     case (TypeInfo(clazz, _), json) =>
       json match {
@@ -69,7 +67,6 @@ abstract class LSerializer[L: Manifest](labelSerializers: Serializer[L]*) {
 class LEdgeSerializer[L: Manifest](labelSerializers: Serializer[L]*)
     extends LSerializer[L](labelSerializers: _*)
     with Serializer[LEdgeParameters[L]] {
-  private val clazz = classOf[LEdgeParameters[_]]
   override def deserialize(implicit format: Formats) = {
     case (TypeInfo(clazz, _), json) =>
       json match {
@@ -96,7 +93,6 @@ class LEdgeSerializer[L: Manifest](labelSerializers: Serializer[L]*)
 class WLEdgeSerializer[L: Manifest](labelSerializers: Serializer[L]*)
     extends LSerializer[L](labelSerializers: _*)
     with Serializer[WLEdgeParameters[L]] {
-  private val clazz = classOf[WLEdgeParameters[_]]
   override def deserialize(implicit format: Formats) = {
     case (TypeInfo(clazz, _), json) =>
       json match {


### PR DESCRIPTION
With `-Ywarn-unused:privates` the compiler warns now about various
unused things. In test where some false positives, so warnings are
only enabled for the main code.