### PR TITLE
Unexpected failing test

### DIFF
--- a/constrained/src/test/scala/scalax/collection/constrained/TConstrained.scala
+++ b/constrained/src/test/scala/scalax/collection/constrained/TConstrained.scala
@@ -73,7 +73,7 @@ class TConstrainedMutable extends RefSpec with Matchers with Testing[mutable.Gra
       val g = factory[Int, UnDiEdge](1 ~ 2, 2 ~ 3, 3 ~ 4, 4 ~ 1)
 
       shouldLeaveGraphUnchanged(g)(_ +=? 5)
-      (g +=? 5) should be(Left("Warning, you can add only 4 edges at a time"))
+      (g +=? 5) should be(Left(Right(UserConstraints.FailingPostAdd.leftWarning)))
       shouldLeaveGraphUnchanged(g)(_ +=? 1 ~ 5)
       shouldLeaveGraphUnchanged(g)(_ ++=? List(5))
       shouldLeaveGraphUnchanged(g)(_ ++=? List(1 ~ 5))
@@ -237,12 +237,13 @@ private object UserConstraints {
                          passedNodes: Traversable[N],
                          passedEdges: Traversable[E[N]],
                          preCheck: PreCheckResult) =
-      if (passedEdges.size == 4) Right(newGraph) else Left("Warning, you can add only 4 edges at a time")
+      if (passedEdges.size == 4) Right(newGraph) else Left(FailingPostAdd.leftWarning)
 
   }
 
   object FailingPostAdd extends ConstraintCompanion[FailingPostAdd] {
     def apply[N, E[X] <: EdgeLikeIn[X], G <: Graph[N, E]](self: G) = new FailingPostAdd[N, E, G](self)
+    val leftWarning                                                = "warning"
   }
 
   /* Constrains the graph to nodes having a minimal degree of `min` by utilizing pre- and post-checks.

--- a/constrained/src/test/scala/scalax/collection/constrained/TConstrained.scala
+++ b/constrained/src/test/scala/scalax/collection/constrained/TConstrained.scala
@@ -73,6 +73,7 @@ class TConstrainedMutable extends RefSpec with Matchers with Testing[mutable.Gra
       val g = factory[Int, UnDiEdge](1 ~ 2, 2 ~ 3, 3 ~ 4, 4 ~ 1)
 
       shouldLeaveGraphUnchanged(g)(_ +=? 5)
+      (g +=? 5) should be(Left("Warning, you can add only 4 edges at a time"))
       shouldLeaveGraphUnchanged(g)(_ +=? 1 ~ 5)
       shouldLeaveGraphUnchanged(g)(_ ++=? List(5))
       shouldLeaveGraphUnchanged(g)(_ ++=? List(1 ~ 5))
@@ -236,7 +237,7 @@ private object UserConstraints {
                          passedNodes: Traversable[N],
                          passedEdges: Traversable[E[N]],
                          preCheck: PreCheckResult) =
-      if (passedEdges.size == 4) Right(newGraph) else Left(())
+      if (passedEdges.size == 4) Right(newGraph) else Left("Warning, you can add only 4 edges at a time")
 
   }
 


### PR DESCRIPTION
I was trying to put at least one example of using the Left verbose reply.

But I stumbled into something unexpected.
This tests correct if we write:
`(g +=? 5) should be(Left(Right("Warning, you can add only 4 edges at a time")))`

