### PR TITLE
Configure test scope for Netbeans dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,8 @@ lazy val core = project
         val netbeansApiOrg     = "org.netbeans.api"
         val release            = "RELEASE123"
 
-        def netbeansModule(module: String) = netbeansModulesOrg % module % release
-        def netbeansApi(module: String)    = netbeansApiOrg     % module % release
+        def netbeansModule(module: String) = netbeansModulesOrg % module % release % "test"
+        def netbeansApi(module: String)    = netbeansApiOrg     % module % release % "test"
         Seq(
           "org.gephi" % "gephi-toolkit" % "0.9.2" % "test" classifier "all" excludeAll (
             ExclusionRule(organization = netbeansModulesOrg),


### PR DESCRIPTION
The Netbeans dependencies are only used (transitively, through Gephi AFAIK) in tests. Therefore they should have test scope as well. 

After upgrading to graph-core 1.13.4 we're getting all these netbeans dependencies in our assembled project jar, unnecessarily adding ~7 MB and causing shading problems (due to duplicate files in those jars).