### PR TITLE
resolve -Xsource:3 errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Cache SBT
-        uses: actions/cache@v3
+      - name: Set up JDK 17 with SBT caching
+        uses: actions/setup-java@v4
         with:
-          path: |
-            ~/.ivy2/cache
-            ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
-      - uses: olafurpg/setup-scala@v14
-        with:
-          java-version: adopt@1.11
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'sbt'
       - name: Test
         run: |
           sbt ++${{ matrix.scala }} test scalafmtCheckAll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17 with SBT caching
+      - name: JDK with SBT caching
         uses: actions/setup-java@v4
         with:
           java-version: '17'

--- a/core/src/main/scala/scalax/collection/GraphTraversal.scala
+++ b/core/src/main/scala/scalax/collection/GraphTraversal.scala
@@ -1116,7 +1116,7 @@ trait GraphTraversal[N, E <: Edge[N]] extends GraphBase[N, E, GraphTraversal] {
           case e: InnerEdgeTraverser => e
           case _                     => innerEdgeTraverser(root, parameters, subgraphNodes, subgraphEdges, ordering)
         }
-        edgeTraverser foreach { e: EdgeT =>
+        edgeTraverser foreach { (e: EdgeT) =>
           b += e
         }
         b.result

--- a/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
+++ b/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
@@ -121,10 +121,10 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
     )(_ => edges.slice(0, edges.size - 1))
 
     def result(): Walk = new Walk {
-      val nodes                  = self.nodes
-      def edges: Iterable[EdgeT] = resultEdges
-      val startNode: NodeT       = start
-      val endNode                = nodes(nodes.size - 1)
+      val nodes: IndexedSeq[NodeT] = self.nodes
+      def edges: IndexedSeq[EdgeT] = resultEdges
+      val startNode: NodeT         = start
+      val endNode                  = nodes(nodes.size - 1)
     }
   }
 

--- a/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
+++ b/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
@@ -1,9 +1,8 @@
 package scalax.collection
 
 import scala.annotation.{switch, tailrec}
-import scala.collection.{AbstractIterable, EqSetFacade, IndexedSeq, Seq}
-import scala.collection.mutable.{ArrayBuffer, Buffer, Map => MMap, Stack}
-
+import scala.collection.{AbstractIterable, EqSetFacade, IndexedSeq, Seq, mutable}
+import scala.collection.mutable.{ArrayBuffer, Buffer, Stack, Map => MMap}
 import scalax.collection.generic.Edge
 import scalax.collection.mutable.{EqHashMap, EqHashSet}
 
@@ -122,10 +121,10 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
     )(_ => edges.slice(0, edges.size - 1))
 
     def result(): Walk = new Walk {
-      val nodes     = self.nodes
-      def edges     = resultEdges
-      val startNode = start
-      val endNode   = nodes(nodes.size - 1)
+      val nodes: mutable.Seq[NodeT] = self.nodes
+      def edges: Iterable[EdgeT]    = resultEdges
+      val startNode: NodeT          = start
+      val endNode                   = nodes(nodes.size - 1)
     }
   }
 
@@ -165,10 +164,10 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
     }
 
     override def result(): Path = new Path {
-      val nodes     = self.nodes
-      val edges     = resultEdges
-      val startNode = start
-      val endNode   = nodes(nodes.size - 1)
+      val nodes: mutable.Seq[NodeT] = self.nodes
+      val edges: Iterable[EdgeT]    = resultEdges
+      val startNode: NodeT          = start
+      val endNode                   = nodes(nodes.size - 1)
     }
   }
 
@@ -285,7 +284,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
       }
     }
 
-    override def iterator = components.iterator
+    override def iterator: Iterator[Component] = components.iterator
 
     def findCycle[U](implicit visitor: InnerElem => U = Visitor.empty): Option[Cycle] =
       if (order == 0) None
@@ -338,7 +337,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
       subgraphEdges: EdgePredicate = anyEdge,
       ordering: ElemOrdering = NoOrdering,
       maxWeight: Option[Weight] = None
-  ) =
+  ): ComponentTraverser =
     ComponentTraverserImpl(null.asInstanceOf[NodeT], parameters, subgraphNodes, subgraphEdges, ordering, maxWeight)
 
   protected case class StrongComponentTraverserImpl(
@@ -375,7 +374,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
       subgraphEdges: EdgePredicate = anyEdge,
       ordering: ElemOrdering = NoOrdering,
       maxWeight: Option[Weight] = None
-  ) =
+  ): StrongComponentTraverser =
     StrongComponentTraverserImpl(
       null.asInstanceOf[NodeT],
       parameters,
@@ -410,7 +409,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
       subgraphEdges: EdgePredicate = anyEdge,
       ordering: ElemOrdering = NoOrdering,
       maxWeight: Option[Weight] = None
-  ) =
+  ): InnerNodeTraverser =
     InnerNodeTraverserImpl(root, parameters, subgraphNodes, subgraphEdges, ordering, maxWeight)
 
   protected case class OuterNodeTraverserImpl(
@@ -440,7 +439,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
       subgraphEdges: EdgePredicate = anyEdge,
       ordering: ElemOrdering = NoOrdering,
       maxWeight: Option[Weight] = None
-  ) =
+  ): OuterNodeTraverser =
     OuterNodeTraverserImpl(root, parameters, subgraphNodes, subgraphEdges, ordering, maxWeight)
 
   protected case class InnerEdgeTraverserImpl(
@@ -469,7 +468,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
       subgraphEdges: EdgePredicate = anyEdge,
       ordering: ElemOrdering = NoOrdering,
       maxWeight: Option[Weight] = None
-  ) =
+  ): InnerEdgeTraverser =
     InnerEdgeTraverserImpl(root, parameters, subgraphNodes, subgraphEdges, ordering, maxWeight)
 
   protected case class OuterEdgeTraverserImpl(
@@ -498,7 +497,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
       subgraphEdges: EdgePredicate = anyEdge,
       ordering: ElemOrdering = NoOrdering,
       maxWeight: Option[Weight] = None
-  ) =
+  ): OuterEdgeTraverser =
     OuterEdgeTraverserImpl(root, parameters, subgraphNodes, subgraphEdges, ordering, maxWeight)
 
   protected case class InnerElemTraverserImpl(
@@ -526,7 +525,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
       subgraphEdges: EdgePredicate = anyEdge,
       ordering: ElemOrdering = NoOrdering,
       maxWeight: Option[Weight] = None
-  ) =
+  ): InnerElemTraverser =
     InnerElemTraverserImpl(root, parameters, subgraphNodes, subgraphEdges, ordering, maxWeight)
 
   protected case class OuterElemTraverserImpl(
@@ -559,7 +558,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
       subgraphEdges: EdgePredicate = anyEdge,
       ordering: ElemOrdering = NoOrdering,
       maxWeight: Option[Weight] = None
-  ) =
+  ): OuterElemTraverser =
     OuterElemTraverserImpl(root, parameters, subgraphNodes, subgraphEdges, ordering, maxWeight)
 
   protected trait DownUpTraverser[A, +CC <: DownUpTraverser[A, CC]] extends Impl[A, CC] {
@@ -603,7 +602,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
       subgraphEdges: EdgePredicate = anyEdge,
       ordering: ElemOrdering = NoOrdering,
       maxWeight: Option[Weight] = None
-  ) =
+  ): InnerNodeDownUpTraverser =
     InnerNodeDownUpTraverserImpl(root, parameters, subgraphNodes, subgraphEdges, ordering, maxWeight)
 
   protected case class OuterNodeDownUpTraverserImpl(
@@ -636,7 +635,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
       subgraphEdges: EdgePredicate = anyEdge,
       ordering: ElemOrdering = NoOrdering,
       maxWeight: Option[Weight] = None
-  ) =
+  ): OuterNodeDownUpTraverser =
     OuterNodeDownUpTraverserImpl(root, parameters, subgraphNodes, subgraphEdges, ordering, maxWeight)
 
   /** Efficient reverse `foreach` overcoming `Stack`'s deficiency not to overwrite `reverseIterator`.
@@ -659,7 +658,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
 
     // TODO unreachable?
     def reverse: Iterable[NodeT] = new AbstractIterable[NodeT] {
-      override def iterator = ???
+      override def iterator: Iterator[NodeT] = ???
       /* TODO replace foreach with iterator
       def foreach[U](f: NodeT => U): Unit = {
         def fT(elem: S): Unit = f(elem.node)
@@ -742,7 +741,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
     */
   abstract protected class SimpleLazyPath(override val nodes: Iterable[NodeT]) extends LazyPath(nodes) {
 
-    final lazy val edges = {
+    final lazy val edges: Iterable[EdgeT] = {
       val buf = new ArrayBuffer[EdgeT](nodes.size) {
         final override protected def className = "Edges"
       }
@@ -792,7 +791,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
 
     final protected val multi = new EqHashSet[EdgeT](thisGraph.size / 2)
 
-    final lazy val edges = {
+    final lazy val edges: Iterable[EdgeT] = {
       val buf = new ArrayBuffer[EdgeT](nodes.size) {
         final override protected def className = "Edges"
       }

--- a/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
+++ b/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
@@ -320,7 +320,7 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
       else {
         val topoRunner    = innerElemTraverser.Runner(noNode, visitor)
         val forStartNodes = innerNodeTraverser(root, Parameters.Dfs(AnyConnected))
-        withHandles(2) { handles: Array[Handle] =>
+        withHandles(2) { (handles: Array[Handle]) =>
           val (startNodesHandle, topoHandle) = (Some(handles(0)), Some(handles(1)))
           implicit val handle: State.Handle  = startNodesHandle.get
           for (node <- nodes if !node.visited && subgraphNodes(node))

--- a/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
+++ b/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
@@ -1,7 +1,7 @@
 package scalax.collection
 
 import scala.annotation.{switch, tailrec}
-import scala.collection.{AbstractIterable, EqSetFacade, IndexedSeq, Seq, mutable}
+import scala.collection.{AbstractIterable, EqSetFacade, IndexedSeq, Seq}
 import scala.collection.mutable.{ArrayBuffer, Buffer, Stack, Map => MMap}
 import scalax.collection.generic.Edge
 import scalax.collection.mutable.{EqHashMap, EqHashSet}
@@ -121,10 +121,10 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
     )(_ => edges.slice(0, edges.size - 1))
 
     def result(): Walk = new Walk {
-      val nodes: mutable.Seq[NodeT] = self.nodes
-      def edges: Iterable[EdgeT]    = resultEdges
-      val startNode: NodeT          = start
-      val endNode                   = nodes(nodes.size - 1)
+      val nodes                  = self.nodes
+      def edges: Iterable[EdgeT] = resultEdges
+      val startNode: NodeT       = start
+      val endNode                = nodes(nodes.size - 1)
     }
   }
 

--- a/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
+++ b/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
@@ -164,10 +164,10 @@ trait GraphTraversalImpl[N, E <: Edge[N]] extends GraphTraversal[N, E] with Trav
     }
 
     override def result(): Path = new Path {
-      val nodes: mutable.Seq[NodeT] = self.nodes
-      val edges: Iterable[EdgeT]    = resultEdges
-      val startNode: NodeT          = start
-      val endNode                   = nodes(nodes.size - 1)
+      val nodes: IndexedSeq[NodeT] = self.nodes
+      val edges: IndexedSeq[EdgeT] = resultEdges
+      val startNode: NodeT         = start
+      val endNode                  = nodes(nodes.size - 1)
     }
   }
 

--- a/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
+++ b/core/src/main/scala/scalax/collection/GraphTraversalImpl.scala
@@ -2,7 +2,7 @@ package scalax.collection
 
 import scala.annotation.{switch, tailrec}
 import scala.collection.{AbstractIterable, EqSetFacade, IndexedSeq, Seq}
-import scala.collection.mutable.{ArrayBuffer, Buffer, Stack, Map => MMap}
+import scala.collection.mutable.{ArrayBuffer, Buffer, Map => MMap, Stack}
 import scalax.collection.generic.Edge
 import scalax.collection.mutable.{EqHashMap, EqHashSet}
 

--- a/core/src/main/scala/scalax/collection/OuterImplicits.scala
+++ b/core/src/main/scala/scalax/collection/OuterImplicits.scala
@@ -8,7 +8,7 @@ import scalax.collection.generic.Edge
 object OuterImplicits {
   implicit def nodeSetToOuter[N, E <: Edge[N]](nodes: AnyGraph[N, E]#NodeSetT): Iterable[OuterNode[N]] =
     new AbstractIterable[OuterNode[N]] {
-      def iterator = new AbstractIterator[OuterNode[N]] {
+      def iterator: Iterator[OuterNode[N]] = new AbstractIterator[OuterNode[N]] {
         private[this] val it = nodes.iterator
 
         def hasNext = it.hasNext
@@ -22,7 +22,7 @@ object OuterImplicits {
 
   implicit def edgeSetToOuter[N, E <: Edge[N]](edges: AnyGraph[N, E]#EdgeSetT): Iterable[OuterEdge[N, E]] =
     new AbstractIterable[OuterEdge[N, E]] {
-      def iterator = new AbstractIterator[OuterEdge[N, E]] {
+      def iterator: Iterator[OuterEdge[N, E]] = new AbstractIterator[OuterEdge[N, E]] {
         private[this] val it = edges.iterator
 
         def hasNext = it.hasNext

--- a/core/src/main/scala/scalax/collection/generator/RandomGraph.scala
+++ b/core/src/main/scala/scalax/collection/generator/RandomGraph.scala
@@ -137,7 +137,7 @@ class RandomGraph[N, E <: Edge[N], G[X, Y <: Edge[X]] <: AnyGraph[X, Y] with Gra
     private[this] var isCompact = false
 
     def sliding2(f: (N, N) => Unit): Unit = {
-      nodes sliding 2 foreach { a: Array[N] =>
+      nodes sliding 2 foreach { (a: Array[N]) =>
         f(a(0), a(1))
       }
       f(nodes(order - 1), nodes(0))

--- a/core/src/main/scala/scalax/collection/immutable/AdjacencyListBase.scala
+++ b/core/src/main/scala/scalax/collection/immutable/AdjacencyListBase.scala
@@ -250,7 +250,7 @@ trait AdjacencyListBase[N, E <: Edge[N], +CC[X, Y <: Edge[X]] <: GraphLike[X, Y,
 
     override def size = nrEdges
 
-    def hasAnyMultiEdge: Boolean = selfGraph.nodes exists { node: NodeT =>
+    def hasAnyMultiEdge: Boolean = selfGraph.nodes exists { (node: NodeT) =>
       val (di: Iterator[EdgeT], unDi: Iterator[EdgeT]) =
         if (selfGraph.isDirected) (node.edges.iterator, Iterator.empty)
         else node.edges.iterator.partition(_.isDirected)

--- a/core/src/main/scala/scalax/collection/immutable/Graph.scala
+++ b/core/src/main/scala/scalax/collection/immutable/Graph.scala
@@ -4,8 +4,7 @@ package immutable
 import java.io.{ObjectInputStream, ObjectOutputStream}
 import scala.collection.Set
 import scalax.collection.AnyGraph
-import scalax.collection.generic.Edge
-import scalax.collection.generic.ImmutableFactory
+import scalax.collection.generic.{Edge, Factory, ImmutableFactory}
 import scalax.collection.config.{AdjacencyListArrayConfig, GraphConfig}
 import scalax.collection.mutable.{ArraySet, Builder}
 
@@ -33,7 +32,7 @@ class DefaultGraphImpl[N, E <: Edge[N]](iniNodes: Iterable[N] = Set[N](), iniEdg
 ) extends Graph[N, E]
     with AdjacencyListGraph[N, E, DefaultGraphImpl]
     with GraphTraversalImpl[N, E] {
-  final override val companion = DefaultGraphImpl
+  final override val companion: Factory[DefaultGraphImpl] = DefaultGraphImpl
 
   @inline final protected def newNodeSet: NodeSetT       = new AdjacencyListNodeSet
   @transient private[this] var _nodes: NodeSetT          = newNodeSet

--- a/core/src/main/scala/scalax/collection/immutable/SortedArraySet.scala
+++ b/core/src/main/scala/scalax/collection/immutable/SortedArraySet.scala
@@ -4,7 +4,7 @@ import java.lang.System.arraycopy
 import scala.collection.generic.DefaultSerializable
 import scala.collection.immutable.{AbstractSet, Set, SortedSet, SortedSetOps, StrictOptimizedSortedSetOps}
 import scala.collection.mutable.{ArrayBuffer, ReusableBuilder}
-import scala.collection.{SortedIterableFactory, SortedSetFactoryDefaults, mutable}
+import scala.collection.{SortedIterableFactory, SortedSetFactoryDefaults}
 
 @SerialVersionUID(1L)
 class SortedArraySet[A](array: Array[A] = new Array[AnyRef](0).asInstanceOf[Array[A]])(implicit
@@ -97,7 +97,7 @@ object SortedArraySet extends SortedIterableFactory[SortedArraySet] {
   override def from[E](it: IterableOnce[E])(implicit ordering: Ordering[E]): SortedArraySet[E] =
     newBuilder.addAll(it).result()
 
-  override def newBuilder[A](implicit ordering: Ordering[A]): mutable.Builder[A, SortedArraySet[A]] = new ReusableBuilder[A, SortedArraySet[A]] {
+  override def newBuilder[A](implicit ordering: Ordering[A]): ReusableBuilder[A, SortedArraySet[A]] = new ReusableBuilder[A, SortedArraySet[A]] {
     val buffer = new ArrayBuffer[AnyRef]
 
     override def clear(): Unit   = buffer.clear()

--- a/core/src/main/scala/scalax/collection/immutable/SortedArraySet.scala
+++ b/core/src/main/scala/scalax/collection/immutable/SortedArraySet.scala
@@ -1,11 +1,10 @@
 package scalax.collection.immutable
 
 import java.lang.System.arraycopy
-
 import scala.collection.generic.DefaultSerializable
 import scala.collection.immutable.{AbstractSet, Set, SortedSet, SortedSetOps, StrictOptimizedSortedSetOps}
 import scala.collection.mutable.{ArrayBuffer, ReusableBuilder}
-import scala.collection.{SortedIterableFactory, SortedSetFactoryDefaults}
+import scala.collection.{SortedIterableFactory, SortedSetFactoryDefaults, mutable}
 
 @SerialVersionUID(1L)
 class SortedArraySet[A](array: Array[A] = new Array[AnyRef](0).asInstanceOf[Array[A]])(implicit
@@ -18,7 +17,7 @@ class SortedArraySet[A](array: Array[A] = new Array[AnyRef](0).asInstanceOf[Arra
     with DefaultSerializable { self =>
   java.util.Arrays.sort(array.asInstanceOf[Array[AnyRef]], ordering.asInstanceOf[Ordering[Object]])
 
-  override def sortedIterableFactory = SortedArraySet
+  override def sortedIterableFactory: SortedArraySet.type = SortedArraySet
 
   override def incl(elem: A): SortedArraySet[A] =
     if (contains(elem)) this
@@ -98,7 +97,7 @@ object SortedArraySet extends SortedIterableFactory[SortedArraySet] {
   override def from[E](it: IterableOnce[E])(implicit ordering: Ordering[E]): SortedArraySet[E] =
     newBuilder.addAll(it).result()
 
-  override def newBuilder[A](implicit ordering: Ordering[A]) = new ReusableBuilder[A, SortedArraySet[A]] {
+  override def newBuilder[A](implicit ordering: Ordering[A]): mutable.Builder[A, SortedArraySet[A]] = new ReusableBuilder[A, SortedArraySet[A]] {
     val buffer = new ArrayBuffer[AnyRef]
 
     override def clear(): Unit   = buffer.clear()

--- a/core/src/main/scala/scalax/collection/immutable/SortedArraySet.scala
+++ b/core/src/main/scala/scalax/collection/immutable/SortedArraySet.scala
@@ -97,11 +97,12 @@ object SortedArraySet extends SortedIterableFactory[SortedArraySet] {
   override def from[E](it: IterableOnce[E])(implicit ordering: Ordering[E]): SortedArraySet[E] =
     newBuilder.addAll(it).result()
 
-  override def newBuilder[A](implicit ordering: Ordering[A]): ReusableBuilder[A, SortedArraySet[A]] = new ReusableBuilder[A, SortedArraySet[A]] {
-    val buffer = new ArrayBuffer[AnyRef]
+  override def newBuilder[A](implicit ordering: Ordering[A]): ReusableBuilder[A, SortedArraySet[A]] =
+    new ReusableBuilder[A, SortedArraySet[A]] {
+      val buffer = new ArrayBuffer[AnyRef]
 
-    override def clear(): Unit   = buffer.clear()
-    override def result()        = new SortedArraySet(buffer.toArray.asInstanceOf[Array[A]])
-    override def addOne(elem: A) = { buffer.addOne(elem.asInstanceOf[AnyRef]); this }
-  }
+      override def clear(): Unit   = buffer.clear()
+      override def result()        = new SortedArraySet(buffer.toArray.asInstanceOf[Array[A]])
+      override def addOne(elem: A) = { buffer.addOne(elem.asInstanceOf[AnyRef]); this }
+    }
 }

--- a/core/src/main/scala/scalax/collection/mutable/ArraySet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/ArraySet.scala
@@ -2,7 +2,7 @@ package scalax.collection
 package mutable
 
 import scala.collection.mutable.{AbstractSet, GrowableBuilder, SetOps}
-import scala.collection.{ExtSetMethods, IterableFactory, IterableFactoryDefaults, SortedSet}
+import scala.collection.{ExtSetMethods, IterableFactory, IterableFactoryDefaults, SortedSet, mutable}
 
 /** A growable and compactable `mutable.Set` implementation based on `Array` and `mutable.Set`.
   *  It switches to the latter representation as soon as a given threshold for the number of
@@ -82,7 +82,7 @@ object ArraySet extends IterableFactory[ArraySet] {
   def apply[A](elem1: A, elem2: A, elems: A*)(implicit hints: Hints): ArraySet[A] =
     emptyWithHints[A](hints) += elem1 += elem2 ++= elems
 
-  override def newBuilder[A] =
+  override def newBuilder[A]: mutable.Builder[A, ArraySet[A]] =
     new GrowableBuilder[A, ArraySet[A]](SimpleArraySet.empty[A]) {
       override def sizeHint(size: Int) = elems.sizeHint(size)
     }

--- a/core/src/main/scala/scalax/collection/mutable/ArraySet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/ArraySet.scala
@@ -2,7 +2,7 @@ package scalax.collection
 package mutable
 
 import scala.collection.mutable.{AbstractSet, GrowableBuilder, SetOps}
-import scala.collection.{ExtSetMethods, IterableFactory, IterableFactoryDefaults, SortedSet, mutable}
+import scala.collection.{ExtSetMethods, IterableFactory, IterableFactoryDefaults, SortedSet}
 
 /** A growable and compactable `mutable.Set` implementation based on `Array` and `mutable.Set`.
   *  It switches to the latter representation as soon as a given threshold for the number of
@@ -82,7 +82,7 @@ object ArraySet extends IterableFactory[ArraySet] {
   def apply[A](elem1: A, elem2: A, elems: A*)(implicit hints: Hints): ArraySet[A] =
     emptyWithHints[A](hints) += elem1 += elem2 ++= elems
 
-  override def newBuilder[A]: mutable.Builder[A, ArraySet[A]] =
+  override def newBuilder[A]: GrowableBuilder[A, ArraySet[A]] =
     new GrowableBuilder[A, ArraySet[A]](SimpleArraySet.empty[A]) {
       override def sizeHint(size: Int) = elems.sizeHint(size)
     }

--- a/core/src/main/scala/scalax/collection/mutable/ExtBitSet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/ExtBitSet.scala
@@ -91,7 +91,7 @@ final protected[collection] class ExtBitSet(words: Array[Long]) extends BitSet(w
     elems = newElems
   }
 
-  override protected def writeReplace() = this
+  override protected def writeReplace(): ExtBitSet = this
 }
 
 object ExtBitSet {

--- a/core/src/main/scala/scalax/collection/mutable/Graph.scala
+++ b/core/src/main/scala/scalax/collection/mutable/Graph.scala
@@ -185,7 +185,7 @@ class DefaultGraphImpl[N, E <: Edge[N]](iniNodes: Iterable[N] = Set[N](), iniEdg
 ) extends Graph[N, E]
     with AdjacencyListGraph[N, E, DefaultGraphImpl]
     with GraphTraversalImpl[N, E] {
-  final override val companion = DefaultGraphImpl
+  final override val companion: Factory[DefaultGraphImpl] = DefaultGraphImpl
 
   @inline final protected def newNodeSet: NodeSetT = new AdjacencyListNodeSet
 

--- a/core/src/main/scala/scalax/collection/mutable/SimpleArraySet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/SimpleArraySet.scala
@@ -37,11 +37,11 @@ final class SimpleArraySet[A](override val hints: ArraySet.Hints)
   }
   initialize()
 
-  def capacity: Int                      = if (isHash) 0 else arr.length
-  @inline private def isHash: Boolean    = arr eq null
-  @inline def isArray: Boolean           = !isHash
-  protected[collection] def array        = arr
-  protected[collection] def set: MSet[A] = hashSet
+  def capacity: Int                         = if (isHash) 0 else arr.length
+  @inline private def isHash: Boolean       = arr eq null
+  @inline def isArray: Boolean              = !isHash
+  protected[collection] def array: Array[A] = arr
+  protected[collection] def set: MSet[A]    = hashSet
 
   def addOne(elem: A) = { add(elem); this }
 

--- a/core/src/main/scala/scalax/collection/mutable/SimpleArraySet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/SimpleArraySet.scala
@@ -22,7 +22,7 @@ final class SimpleArraySet[A](override val hints: ArraySet.Hints)
     with IterableFactoryDefaults[A, SimpleArraySet]
     with Serializable {
 
-  override def iterableFactory = SimpleArraySet
+  override def iterableFactory: IterableFactory[SimpleArraySet] = SimpleArraySet
 
   protected[collection] def newNonCheckingBuilder[B] = new SimpleArraySet.NonCheckingBuilder[A, B](this)
   override def clone: ArraySet[A]                    = (newNonCheckingBuilder ++= this).result()

--- a/core/src/main/scala/scalax/collection/mutable/SimpleArraySet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/SimpleArraySet.scala
@@ -282,5 +282,6 @@ object SimpleArraySet extends IterableFactory[SimpleArraySet] {
   }
 
   override def from[A](source: IterableOnce[A]) = empty ++= source
-  override def newBuilder[A]                    = new GrowableBuilder[A, SimpleArraySet[A]](empty)
+
+  override def newBuilder[A]: GrowableBuilder[A, SimpleArraySet[A]] = new GrowableBuilder[A, SimpleArraySet[A]](empty)
 }

--- a/core/src/main/scala/scalax/collection/mutable/SimpleArraySet.scala
+++ b/core/src/main/scala/scalax/collection/mutable/SimpleArraySet.scala
@@ -25,7 +25,7 @@ final class SimpleArraySet[A](override val hints: ArraySet.Hints)
   override def iterableFactory = SimpleArraySet
 
   protected[collection] def newNonCheckingBuilder[B] = new SimpleArraySet.NonCheckingBuilder[A, B](this)
-  override def clone                                 = (newNonCheckingBuilder ++= this).result()
+  override def clone: ArraySet[A]                    = (newNonCheckingBuilder ++= this).result()
   private var nextFree: Int                          = 0
   private var arr: Array[A]                          = _
   private var hashSet: ExtHashSet[A]                 = _
@@ -37,11 +37,11 @@ final class SimpleArraySet[A](override val hints: ArraySet.Hints)
   }
   initialize()
 
-  def capacity: Int                   = if (isHash) 0 else arr.length
-  @inline private def isHash: Boolean = arr eq null
-  @inline def isArray: Boolean        = !isHash
-  protected[collection] def array     = arr
-  protected[collection] def set       = hashSet
+  def capacity: Int                      = if (isHash) 0 else arr.length
+  @inline private def isHash: Boolean    = arr eq null
+  @inline def isArray: Boolean           = !isHash
+  protected[collection] def array        = arr
+  protected[collection] def set: MSet[A] = hashSet
 
   def addOne(elem: A) = { add(elem); this }
 


### PR DESCRIPTION
These 4 errors were highlighted (among others) by adding

`scalacOptions ++= Seq("-Xsource:3")`

to `build.sbt`.

The change appears to be harmless for Scala2, so it might be considered as a non-breaking migration step.