### PR TITLE
Enable Scala 3 migration mode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,6 +97,9 @@ val unusedImports = "-Wunused:imports"
 
 lazy val defaultSettings_2_13 = Defaults.coreDefaultSettings ++ Seq(
   scalaVersion := Version.compiler_2_13,
+  scalacOptions ++= Seq(
+    "-Xsource:3-cross"
+  ),
   libraryDependencies ++= Seq(
     "org.scalatest"     %% "scalatest"       % "3.2.19"   % Test,
     "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % Test

--- a/core/src/main/scala/scalax/collection/hyperedges/ordered/HyperEdge.scala
+++ b/core/src/main/scala/scalax/collection/hyperedges/ordered/HyperEdge.scala
@@ -8,7 +8,7 @@ import scalax.collection.generic.{
 /** Undirected hyperedge with ends having sequence semantic with respect to equality.
   */
 @SerialVersionUID(-52)
-final case class HyperEdge[+N] private (override val ends: Several[N])
+final case class HyperEdge[+N](override val ends: Several[N])
     extends AbstractUnlabeledGenericHyperEdge[N, HyperEdge](ends)
     with OrderedEndpoints
     with HyperEdgeToString

--- a/core/src/test/scala/demo/GraphTestDemo.scala
+++ b/core/src/test/scala/demo/GraphTestDemo.scala
@@ -92,7 +92,7 @@ object GraphTestDemo extends App {
     type IntDiGraph = Graph[Int, DiEdge[Int]]
     implicit val arbitraryTinyGraph: Arbitrary[Graph[Int, DiEdge[Int]]] = GraphGen.tinyConnectedIntDi[Graph](Graph)
 
-    val properTiny = forAll(arbitrary[IntDiGraph]) { g: IntDiGraph =>
+    val properTiny = forAll(arbitrary[IntDiGraph]) { (g: IntDiGraph) =>
       g.order == GraphGen.TinyInt.order
     }
     properTiny.check()
@@ -111,7 +111,7 @@ object GraphTestDemo extends App {
       GraphGen.fromMetrics[Int, UnDiEdge[Int], Graph](Graph, Sparse_1000_Int, Set(UnDiEdge)).apply
     }
 
-    val properSparse = forAll(arbitrary[IntUnDiGraph]) { g: IntUnDiGraph =>
+    val properSparse = forAll(arbitrary[IntUnDiGraph]) { (g: IntUnDiGraph) =>
       g.order == Sparse_1000_Int.order
     }
     properSparse.check()
@@ -149,7 +149,7 @@ object GraphTestDemo extends App {
         .apply
     }
 
-    val properMixedGraph = forAll(arbitrary[Mixed]) { g: Mixed =>
+    val properMixedGraph = forAll(arbitrary[Mixed]) { (g: Mixed) =>
       g.order == MixedMetrics.order
     }
     properMixedGraph.check()
@@ -169,7 +169,7 @@ object GraphTestDemo extends App {
         implicit val arbitraryTinyGraph: Arbitrary[Graph[Int, DiEdge[Int]]] = GraphGen.tinyConnectedIntDi[Graph](Graph)
 
         def `should conform to tiny metrics`: Unit =
-          forAll(arbitrary[IntDiGraph]) { g: IntDiGraph =>
+          forAll(arbitrary[IntDiGraph]) { (g: IntDiGraph) =>
             g.order should equal(GraphGen.TinyInt.order)
           }
       }

--- a/core/src/test/scala/scalax/collection/CycleSpec.scala
+++ b/core/src/test/scala/scalax/collection/CycleSpec.scala
@@ -20,7 +20,7 @@ private trait CycleMatcher[N, E <: Edge[N]] {
   protected type C = AnyGraph[N, E]#Cycle
 
   def haveOneNodeSequenceOf(expected: Seq[N]*): Matcher[Option[C]] =
-    Matcher { ns: Option[C] =>
+    Matcher { (ns: Option[C]) =>
       val found: Seq[N] = ns match {
         case None       => Seq()
         case Some(path) => path.nodes.toSeq.map(_.outer).toList
@@ -34,7 +34,7 @@ private trait CycleMatcher[N, E <: Edge[N]] {
     }
 
   def beValid: Matcher[Option[C]] =
-    Matcher { c: Option[C] =>
+    Matcher { (c: Option[C]) =>
       def msg(key: String): String = s"$c $key valid"
       MatchResult(c.get.isValid, msg("is not"), msg("is"))
     }

--- a/core/src/test/scala/scalax/collection/EditingSpec.scala
+++ b/core/src/test/scala/scalax/collection/EditingSpec.scala
@@ -7,6 +7,8 @@ import scalax.collection.edges._
 import scalax.collection.generic._
 import scalax.collection.OuterImplicits._
 import scalax.collection.config.GraphConfig
+import scalax.collection.immutable.Graph
+import scalax.collection.config.CoreConfig
 
 /** Editing any kind of non-hypergraph with unlabeled edges including mixed graphs.
   */
@@ -14,12 +16,12 @@ class EditingSpec
     extends Suites(
       new EditingEdges,
       new Editing[immutable.Graph](new ConfigWrapper[immutable.Graph] {
-        val companion = immutable.Graph
-        val config    = immutable.Graph.defaultConfig
+        val companion: Graph.type = immutable.Graph
+        val config: CoreConfig    = immutable.Graph.defaultConfig
       }),
       new Editing[mutable.Graph](new ConfigWrapper[mutable.Graph] {
-        val companion = mutable.Graph
-        val config    = mutable.Graph.defaultConfig
+        val companion: mutable.Graph.type = mutable.Graph
+        val config: CoreConfig            = mutable.Graph.defaultConfig
       }),
       new EditingImmutable,
       new EditingMutable

--- a/core/src/test/scala/scalax/collection/MappingTypedSpec.scala
+++ b/core/src/test/scala/scalax/collection/MappingTypedSpec.scala
@@ -42,7 +42,7 @@ class MappingTypedSpec extends RefSpec with Matchers {
 
     def `upcast nodes to another typed edge within the ADT`: Unit =
       TGraph(AConnector(a_1, a_1)) pipe { g =>
-        g.mapBound[Node, Connector](_ => b_0_0, Connector) pipe { mapped =>
+        g.mapBound[Node, Connector](_ => b_0_0, Connector.apply) pipe { mapped =>
           mapped.edges.head.outer shouldEqual Connector(b_0_0, b_0_0)
         }
       }

--- a/core/src/test/scala/scalax/collection/SerializableSpec.scala
+++ b/core/src/test/scala/scalax/collection/SerializableSpec.scala
@@ -337,7 +337,7 @@ protected object ScalaObjectSerialization extends App {
       def d = "MyDef"
       val v = "MyVal"
     }
-    def inner = Inner
+    def inner: Inner.type = Inner
   }
 
   private trait MyTrait extends Base with Serializable {
@@ -346,7 +346,7 @@ protected object ScalaObjectSerialization extends App {
       def d = "MyDef"
       val v = "MyVal"
     }
-    val inner = Inner
+    val inner: Inner.type = Inner
   }
 
   private class MyClass extends Base with Serializable {
@@ -355,7 +355,7 @@ protected object ScalaObjectSerialization extends App {
       def d = "MyDef"
       val v = "MyVal"
     }
-    val inner = Inner
+    val inner: Inner.type = Inner
   }
 
   import ByteArraySerialization._

--- a/core/src/test/scala/scalax/collection/SetOpsSpec.scala
+++ b/core/src/test/scala/scalax/collection/SetOpsSpec.scala
@@ -11,6 +11,7 @@ import scalax.collection.edges._
 import scalax.collection.generic.{Edge, GenericGraphCoreFactory}
 
 import scalax.collection.visualization.Visualizer
+import scalax.collection.immutable.Graph
 
 class SetOpsSpec
     extends Suites(
@@ -73,12 +74,12 @@ private class SetOps[CC[N, E <: Edge[N]] <: AnyGraph[N, E] with GraphLike[N, E, 
 }
 
 private class SetOpsImmutable extends RefSpec with Matchers with SetOpExamples[immutable.Graph] {
-  protected val factory = immutable.Graph
+  protected val factory: Graph.type = immutable.Graph
 
 }
 
 private class SetOpsMutable extends RefSpec with Matchers with SetOpExamples[mutable.Graph] {
-  protected val factory = mutable.Graph
+  protected val factory: mutable.Graph.type = mutable.Graph
 
   private val iH = immutable.Graph.from(hEdges)
 

--- a/core/src/test/scala/scalax/collection/generator/GraphGenSpec.scala
+++ b/core/src/test/scala/scalax/collection/generator/GraphGenSpec.scala
@@ -67,7 +67,7 @@ class GraphGenSpec extends RefSpec with Matchers with ScalaCheckPropertyChecks {
     implicit val arbitraryGraph: Arbitrary[Graph[Int, DiEdge[Int]]] = GraphGen.tinyConnectedIntDi[Graph](Graph)
 
     def `should conform to tiny metrics`: Unit =
-      forAll(arbitrary[IntDiGraph]) { g: IntDiGraph =>
+      forAll(arbitrary[IntDiGraph]) { (g: IntDiGraph) =>
         checkMetrics(g, GraphGen.TinyInt)
       }
   }
@@ -76,7 +76,7 @@ class GraphGenSpec extends RefSpec with Matchers with ScalaCheckPropertyChecks {
     implicit val arbitraryGraph: Arbitrary[Graph[Int, DiEdge[Int]]] = GraphGen.smallConnectedIntDi[Graph](Graph)
 
     def `should conform to small metrics`: Unit =
-      forAll(arbitrary[IntDiGraph]) { g: IntDiGraph =>
+      forAll(arbitrary[IntDiGraph]) { (g: IntDiGraph) =>
         checkMetrics(g, GraphGen.SmallInt)
       }
   }

--- a/core/src/test/scala/scalax/collection/labeled/TraversalSpec.scala
+++ b/core/src/test/scala/scalax/collection/labeled/TraversalSpec.scala
@@ -245,7 +245,7 @@ final private class Traversal[G[N, E <: Edge[N]] <: AnyGraph[N, E] with GraphLik
       shp4.get.edges.toList should be(List(flight("UA 8840"), flight("LH 1480")))
 
       val visited = MSet[g.EdgeT]()
-      (g get jfc).innerEdgeTraverser.shortestPathTo(g get lhr) { e: g.EdgeT =>
+      (g get jfc).innerEdgeTraverser.shortestPathTo(g get lhr) { (e: g.EdgeT) =>
         visited += e
       }
       val visitedSorted = visited.toList.sortWith((a: g.EdgeT, b: g.EdgeT) => a.flightNo < b.flightNo)

--- a/core/src/test/scala/scalax/time/MicroBenchmark.scala
+++ b/core/src/test/scala/scalax/time/MicroBenchmark.scala
@@ -35,7 +35,7 @@ object MicroBenchmark {
     def toFloat(x: NanoSecond)                          = x.value.toFloat
     def toDouble(x: NanoSecond)                         = x.value.toDouble
     def compare(x: NanoSecond, y: NanoSecond)           = num.compare(x, y)
-    def parseString(str: String)                        = throw new UnsupportedOperationException
+    def parseString(str: String): Nothing               = throw new UnsupportedOperationException
   }
 
   sealed abstract class MeasurementResult[A](result: A) {

--- a/json/src/main/scala/scalax/collection/io/json/descriptor/EdgeDescriptor.scala
+++ b/json/src/main/scala/scalax/collection/io/json/descriptor/EdgeDescriptor.scala
@@ -82,7 +82,7 @@ class EdgeDescriptor[N, E <: AnyEdge[N]](
 
   def extract(jsonEdge: JValue): EdgeParameters = jsonEdge.extract[EdgeParameters]
 
-  protected def toParameters(edge: E)(implicit descriptor: Descriptor[N]) = {
+  protected def toParameters(edge: E)(implicit descriptor: Descriptor[N]): EdgeParameters = {
     val (n1, n2) = (edge.node1, edge.node2)
     EdgeParameters(descriptor.nodeDescriptor(n1) id n1, descriptor.nodeDescriptor(n2) id n2)
   }
@@ -110,7 +110,7 @@ abstract class LEdgeDescriptor[N, E <: AnyEdge[N], L](
 
   def extract(jsonEdge: JValue): LEdgeParameters[L] = jsonEdge.extract[LEdgeParameters[L]]
 
-  protected def toParameters(edge: E)(implicit descriptor: Descriptor[N]) =
+  protected def toParameters(edge: E)(implicit descriptor: Descriptor[N]): LEdgeParameters[Any] =
     LEdgeParameters(
       descriptor.nodeDescriptor(edge.node1) id edge.node1,
       descriptor.nodeDescriptor(edge.node2) id edge.node2,
@@ -136,7 +136,7 @@ class HyperEdgeDescriptor[N, E <: AbstractHyperEdge[N]](
 
   def extract(jsonEdge: JValue): HyperEdgeParameters = jsonEdge.extract[HyperEdgeParameters]
 
-  protected def toParameters(edge: E)(implicit descriptor: Descriptor[N]) =
+  protected def toParameters(edge: E)(implicit descriptor: Descriptor[N]): HyperEdgeParameters =
     HyperEdgeParameters(nodeIds(edge, descriptor))
 }
 
@@ -160,7 +160,7 @@ abstract class LHyperEdgeDescriptor[N, E <: AbstractHyperEdge[N], L](
 
   def extract(jsonEdge: JValue): LHyperEdgeParameters[L] = jsonEdge.extract[LHyperEdgeParameters[L]]
 
-  protected def toParameters(edge: E)(implicit descriptor: Descriptor[N]) =
+  protected def toParameters(edge: E)(implicit descriptor: Descriptor[N]): LHyperEdgeParameters[Any] =
     LHyperEdgeParameters(nodeIds(edge, descriptor), label(edge))
 }
 

--- a/json/src/main/scala/scalax/collection/io/json/descriptor/predefined/edgeDescriptors.scala
+++ b/json/src/main/scala/scalax/collection/io/json/descriptor/predefined/edgeDescriptors.scala
@@ -28,7 +28,7 @@ trait PredefinedEdgeDescriptor extends PredefinedEdgeDescriptorBase {
 }
 
 case object UnDi extends PredefinedEdgeDescriptor {
-  def descriptor[N](customSerializer: Option[Serializer[_ <: Parameters]] = None) =
+  def descriptor[N](customSerializer: Option[Serializer[_ <: Parameters]] = None): EdgeDescriptor[N, UnDiEdge[N]] =
     new EdgeDescriptor[N, UnDiEdge[N]](
       UnDiEdge.apply,
       check[EdgeParameters](customSerializer),
@@ -38,7 +38,9 @@ case object UnDi extends PredefinedEdgeDescriptor {
 }
 
 case object WUnDi extends PredefinedEdgeDescriptor {
-  def descriptor[N](customSerializer: Option[Serializer[_ <: Parameters]] = some.wEdgeSerializer) =
+  def descriptor[N](
+      customSerializer: Option[Serializer[_ <: Parameters]] = some.wEdgeSerializer
+  ): LEdgeDescriptor[N, WUnDiEdge[N], Double] =
     new LEdgeDescriptor[N, WUnDiEdge[N], Double](
       WUnDiEdge.apply,
       Double.MaxValue,
@@ -51,7 +53,9 @@ case object WUnDi extends PredefinedEdgeDescriptor {
 }
 
 case object MultiWUnDi extends PredefinedEdgeDescriptor {
-  override def descriptor[N](customSerializer: Option[Serializer[_ <: Parameters]] = some.wEdgeSerializer) =
+  override def descriptor[N](
+      customSerializer: Option[Serializer[_ <: Parameters]] = some.wEdgeSerializer
+  ): LEdgeDescriptor[N, MultiWUnDiEdge[N], Double] =
     new LEdgeDescriptor[N, MultiWUnDiEdge[N], Double](
       MultiWUnDiEdge.apply,
       Double.MaxValue,
@@ -64,12 +68,16 @@ case object MultiWUnDi extends PredefinedEdgeDescriptor {
 }
 
 case object Di extends PredefinedEdgeDescriptor {
-  override def descriptor[N](customSerializer: Option[Serializer[_ <: Parameters]] = None) =
+  override def descriptor[N](
+      customSerializer: Option[Serializer[_ <: Parameters]] = None
+  ): EdgeDescriptor[N, DiEdge[N]] =
     new EdgeDescriptor[N, DiEdge[N]](DiEdge.apply, check(customSerializer), Nil, caseObjectBasedTypeId)
 }
 
 case object WDi extends PredefinedEdgeDescriptor {
-  override def descriptor[N](customSerializer: Option[Serializer[_ <: Parameters]] = some.wEdgeSerializer) =
+  override def descriptor[N](
+      customSerializer: Option[Serializer[_ <: Parameters]] = some.wEdgeSerializer
+  ): LEdgeDescriptor[N, WDiEdge[N], Double] =
     new LEdgeDescriptor[N, WDiEdge[N], Double](
       WDiEdge.apply,
       Double.MaxValue,
@@ -82,7 +90,9 @@ case object WDi extends PredefinedEdgeDescriptor {
 }
 
 case object MultiWDi extends PredefinedEdgeDescriptor {
-  override def descriptor[N](customSerializer: Option[Serializer[_ <: Parameters]] = some.wEdgeSerializer) =
+  override def descriptor[N](
+      customSerializer: Option[Serializer[_ <: Parameters]] = some.wEdgeSerializer
+  ): LEdgeDescriptor[N, MultiWDiEdge[N], Double] =
     new LEdgeDescriptor[N, MultiWDiEdge[N], Double](
       MultiWDiEdge.apply,
       Double.MaxValue,
@@ -95,7 +105,9 @@ case object MultiWDi extends PredefinedEdgeDescriptor {
 }
 
 case object Hyper extends PredefinedEdgeDescriptor {
-  override def descriptor[N](customSerializer: Option[Serializer[_ <: Parameters]] = some.hyperEdgeSerializer) =
+  override def descriptor[N](
+      customSerializer: Option[Serializer[_ <: Parameters]] = some.hyperEdgeSerializer
+  ): HyperEdgeDescriptor[N, HyperEdge[N]] =
     new HyperEdgeDescriptor[N, HyperEdge[N]](
       HyperEdge.apply,
       check[HyperEdgeParameters](customSerializer),
@@ -105,7 +117,9 @@ case object Hyper extends PredefinedEdgeDescriptor {
 }
 
 case object DiHyper extends PredefinedEdgeDescriptor {
-  override def descriptor[N](customSerializer: Option[Serializer[_ <: Parameters]] = some.diHyperEdgeSerializer) =
+  override def descriptor[N](
+      customSerializer: Option[Serializer[_ <: Parameters]] = some.diHyperEdgeSerializer
+  ): DiHyperEdgeDescriptor[N, DiHyperEdge[N]] =
     new DiHyperEdgeDescriptor[N, DiHyperEdge[N]](DiHyperEdge.apply, check(customSerializer), Nil, caseObjectBasedTypeId)
 }
 

--- a/json/src/main/scala/scalax/collection/io/json/exp/Export.scala
+++ b/json/src/main/scala/scalax/collection/io/json/exp/Export.scala
@@ -18,7 +18,7 @@ class Export[N, E <: Edge[N]](
 
   def jsonASTNodes: JField = {
     val classNodesMap =
-      graph.nodes.toOuter groupBy { a: Any =>
+      graph.nodes.toOuter groupBy { (a: Any) =>
         val clazz = a.asInstanceOf[AnyRef].getClass
         if (simpleClassNames) clazz.getSimpleName
         else clazz.getName


### PR DESCRIPTION
As it was suggested in another PR (https://github.com/scala-graph/scala-graph/pull/323) I'm enabling the compiler migration mode first