### PR TITLE
GraphLike: override hashCode.

### DIFF
--- a/core/src/main/scala/scalax/collection/AnyGraph.scala
+++ b/core/src/main/scala/scalax/collection/AnyGraph.scala
@@ -88,6 +88,8 @@ trait GraphLike[N, E <: Edge[N], +CC[X, Y <: Edge[X]] <: GraphLike[X, Y, CC] wit
       false
   }
 
+  override def hashCode(): Int = this.nodes.toOuter.## + 31 * this.edges.toOuter.##
+
   type NodeT <: GraphInnerNode
   trait GraphInnerNode extends BaseInnerNode with TraverserInnerNode { this: NodeT =>
 


### PR DESCRIPTION
According to Joshua Bloch:

> You must override hashCode() in every class that overrides equals(). Failure to do so will result in a violation of the general contract for Object.hashCode(), which will prevent your class from functioning properly in conjunction with all hash-based collections, including HashMap, HashSet, and Hashtable.

In my case this resulted in some really weird behavior involving graph nodes which themselves contain subgraphs.

